### PR TITLE
Improvements on ESP32 flash operations

### DIFF
--- a/source/nanoFirmwareFlasher/Esp32Firmware.cs
+++ b/source/nanoFirmwareFlasher/Esp32Firmware.cs
@@ -17,9 +17,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
     internal class Esp32Firmware : FirmwarePackage
     {
         /// <summary>
-        /// ESP32 nanoCLR is only available for 2MB and 4MB flash sizes
+        /// ESP32 nanoCLR is available for 2MB, 4MB, 8MB and 16MB flash sizes
         /// </summary>
-        internal List<int> SupportedFlashSizes => new List<int> { 0x200000, 0x400000 };
+        internal List<int> SupportedFlashSizes => new List<int> { 0x200000, 0x400000, 0x800000, 0x1000000 };
 
         internal Dictionary<int, string> FlashPartitions;
 
@@ -36,13 +36,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
         internal async System.Threading.Tasks.Task<ExitCodes> DownloadAndExtractAsync(int flashSize)
         {
-            if (!SupportedFlashSizes.Contains(flashSize))
-            { 
-                string humanReadable = flashSize >= 0x10000 ? $"{ flashSize / 0x10000 }MB" : $"{ flashSize / 0x400 }kB";
+            string humanReadable = flashSize >= 0x10000 ? $"{ flashSize / 0x100000 }MB" : $"{ flashSize / 0x400 }kB";
 
+            if (!SupportedFlashSizes.Contains(flashSize))
+            {
                 if (Verbosity >= VerbosityLevel.Detailed)
                 {
-                    Console.WriteLine($"There is no firmware available for ESP32 with {humanReadable} flash size!{Environment.NewLine}Only the following flash sizes are supported: {string.Join(", ", SupportedFlashSizes.Select(size => size >= 0x10000 ? $"{ size / 0x10000 }MB" : $"{ size / 0x400 }kB."))}");
+                    Console.WriteLine($"There is no firmware available for ESP32 with {humanReadable} flash size!{Environment.NewLine}Only the following flash sizes are supported: {string.Join(", ", SupportedFlashSizes.Select(size => size >= 0x10000 ? $"{ size / 0x100000 }MB" : $"{ size / 0x400 }kB."))}");
                 }
 
                 return ExitCodes.E4001;
@@ -62,8 +62,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
 				    // nanoCLR goes to 0x10000
 				    { 0x10000, Path.Combine(LocationPath, "nanoCLR.bin") },
 
-				    // partition table goes to 0x8000; there is on partition table for 2MB flash and one for 4MB flash
-				    { 0x8000, Path.Combine(LocationPath, flashSize == 0x200000 ? "partitions_2mb.bin" : "partitions_4mb.bin") }
+				    // partition table goes to 0x8000; there are partition tables for 2MB, 4MB, 8MB and 16MB flash sizes
+				    { 0x8000, Path.Combine(LocationPath, $"partitions_{humanReadable.ToLowerInvariant()}.bin") }
                 };
             }
 

--- a/source/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/source/nanoFirmwareFlasher/Esp32Operations.cs
@@ -123,25 +123,30 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     }
                 }
 
-                if (verbosity >= VerbosityLevel.Detailed)
+                if (verbosity >= VerbosityLevel.Normal)
                 {
-                    Console.WriteLine($"Erasing flash...");
+                    Console.Write($"Erasing flash...");
                 }
 
                 // erase flash
                 espTool.EraseFlash();
 
-                if (verbosity >= VerbosityLevel.Detailed)
+                if (verbosity >= VerbosityLevel.Normal)
                 {
-                    Console.WriteLine($"Flashing firmware...");
+                    Console.WriteLine("OK");
+                }
+
+                if (verbosity >= VerbosityLevel.Normal)
+                {
+                    Console.Write($"Flashing firmware...");
                 }
 
                 // write to flash
                 espTool.WriteFlash(firmware.FlashPartitions);
 
-                if (verbosity >= VerbosityLevel.Detailed)
+                if (verbosity >= VerbosityLevel.Normal)
                 {
-                    Console.WriteLine("ESP32 successfully flashed!");
+                    Console.WriteLine("OK");
                 }
             }
 

--- a/source/nanoFirmwareFlasher/Program.cs
+++ b/source/nanoFirmwareFlasher/Program.cs
@@ -238,7 +238,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     Console.WriteLine($"Connected to ESP32 { esp32Device.ChipName } with MAC address { esp32Device.MacAddress }");
                     Console.WriteLine($"features { esp32Device.Features }");
-                    Console.WriteLine($"Flash information: manufacturer 0x{ esp32Device.FlashManufacturerId } device 0x{ esp32Device.FlashDeviceModelId } size { esp32Device.FlashSize }");
+
+                    string flashSize = esp32Device.FlashSize >= 0x10000 ? $"{ esp32Device.FlashSize / 0x100000 }MB" : $"{ esp32Device.FlashSize / 0x400 }kB";
+
+                    Console.WriteLine($"Flash information: manufacturer 0x{ esp32Device.FlashManufacturerId } device 0x{ esp32Device.FlashDeviceModelId } size { flashSize }");
                 }
 
                 // set verbosity

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.5-preview.{height}",
+  "version": "1.0.6-preview.{height}",
   "release": {
     "branchName" : "release-v{version}",
     "versionIncrement" : "minor",


### PR DESCRIPTION
- Add support for all supported partition sizes: 2, 4, 8 and 16 MB.
- Improve feedback messages.
- Bump version to 1.0.6-preview.
- Closes nanoframework/Home#505.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>