### PR TITLE
Fix argument evaluation when required arguments are missing

### DIFF
--- a/source/nanoFirmwareFlasher/Esp32Firmware.cs
+++ b/source/nanoFirmwareFlasher/Esp32Firmware.cs
@@ -67,7 +67,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 };
             }
 
-            return ExitCodes.OK;
+            return executionResult;
         }
     }
 }

--- a/source/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/source/nanoFirmwareFlasher/Esp32Operations.cs
@@ -150,7 +150,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
             }
 
-            return ExitCodes.OK;
+            return operationResult;
         }
     }
 }

--- a/source/nanoFirmwareFlasher/ExitCodes.cs
+++ b/source/nanoFirmwareFlasher/ExitCodes.cs
@@ -10,6 +10,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
     public enum ExitCodes : int
     {
         /// <summary>
+        /// Arguments do not parse
+        /// </summary>
+        [Display(Name = "Invalid or missing arguments")]
+        ArgumentError = -1, 
+
+        /// <summary>
         /// Execution terminated without any error
         /// </summary>
         [Display(Name = "")]

--- a/source/nanoFirmwareFlasher/Extensions/CommandLineExtensions.cs
+++ b/source/nanoFirmwareFlasher/Extensions/CommandLineExtensions.cs
@@ -5,6 +5,7 @@
 
 using CommandLine;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 
@@ -34,5 +35,42 @@ namespace nanoFramework.Tools.FirmwareFlasher.Extensions
             }
             return result;
         }
+
+        //public static async Task<ParserResult<T>> WithNotParsedAsync<T>(this Task<ParserResult<T>> task, Action<IEnumerable<Error>> action)
+        //{
+        //    var result = await task;
+        //    if (result is NotParsed<T> notParsed)
+        //    {
+        //        return result.WithNotParsed(action);
+        //    }
+        //    return result;
+        //}
+
+        //public static async Task<ParserResult<T>> WithNotParsedAsync<T>(this ParserResult<T> result, Func<IEnumerable<Error>, Task> errorFunc)
+        //{
+        //    if (result is NotParsed<T> notParsed)
+        //    {
+        //        await errorFunc(notParsed.Errors);
+        //    }
+        //    return result;
+        //}
+
+        /// <summary>
+        ///     Async version of the WithNotParsed taking a Task as input for dot-appending to the WithParsedAsync extension method.
+        /// </summary>
+        /// <typeparam name="T">Type of the target instance built with parsed value.</typeparam>
+        /// <param name="task">A Task of <see cref="CommandLine.ParserResult{T}"/>.</param>
+        /// <param name="errorFunc">The <see cref="Func{<IEnumerable<Error>, Task}"/> to execute.</param>
+        /// <returns>The same <paramref name="task"/> instance as a <see cref="Task"/> instance.</returns>
+        public static async Task<ParserResult<T>> WithNotParsedAsync<T>(this Task<ParserResult<T>> task, Func<IEnumerable<Error>, Task> errorFunc)
+        {
+            var result = await task;
+            if (result is NotParsed<T> notParsed)
+            {
+                await errorFunc(notParsed.Errors);
+            }
+            return result;
+        }
+
     }
 }

--- a/source/nanoFirmwareFlasher/Options.cs
+++ b/source/nanoFirmwareFlasher/Options.cs
@@ -111,7 +111,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
         [Option(
             "target",
-            Required = false,
+            Required = true,
             Default = null,
            HelpText = "Target name. This is the target name used in the GitHub and Bintray repositories.")]
         public string TargetName { get; set; }


### PR DESCRIPTION
I'm not entirely sure if target parameter is mandatory or not.
Also the added enum value ArgumentError is -1, I don't know if you have a preferred grouping of error codes, that colides with this.
But now at least, invalid arguments lead to a clear error message instead of an access violation as before.