### PR TITLE
Add support for flashing deployment image

### DIFF
--- a/source/nanoFirmwareFlasher/ExitCodes.cs
+++ b/source/nanoFirmwareFlasher/ExitCodes.cs
@@ -142,6 +142,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
         [Display(Name = "Address count doesn't match BIN files count. An address needs to be specified for each BIN file.")]
         E5009 = 5009,
 
+        /// <summary>
+        /// Failed to reset MCU.
+        /// </summary>
+        [Display(Name = "Failed to reset MCU on connected device.")]
+        E5010 = 5010,
+
         ////////////////
         // COM Errors //
         ////////////////
@@ -209,5 +215,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// </summary>
         [Display(Name = "Couldn't find application file. Check the path.")]
         E9008 = 9008,
+
+
+        /// <summary>
+        /// Can't program deployment BIN file without specifying a valid address
+        /// </summary>
+        [Display(Name = "Can't program deployment BIN file without specifying a valid deployment address.")]
+        E9009 = 9009,
+
     }
 }

--- a/source/nanoFirmwareFlasher/Options.cs
+++ b/source/nanoFirmwareFlasher/Options.cs
@@ -65,12 +65,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
             HelpText = "BIN file(s) to be flashed into the device.")]
         public IEnumerable<string> BinFile { get; set; }
 
-        [Option(
-            "address",
-            Required = false,
-            HelpText = "Address(es) where to flash the BIN file(s). Hexadecimal format (e.g. 0x08000000). Required when specifying a BIN file with -binfile argument.")]
-        public IEnumerable<string> FlashAddress { get; set; }
-
         #endregion
 
 
@@ -163,9 +157,16 @@ namespace nanoFramework.Tools.FirmwareFlasher
         [Option(
             "update",
             Required = false,
-            Default = true,
+            Default = false,
             HelpText = "Update the device firmware using the other specified options.")]
         public bool Update { get; set; }
+
+        [Option(
+            "deploy",
+            Required = false,
+            Default = false,
+            HelpText = "Flash a deployment image specified with --image.")]
+        public bool Deploy { get; set; }
 
         [Option(
             "stable",
@@ -175,7 +176,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         public bool Stable { get; set; }
 
         [Option(
-            "deployment",
+            "image",
             Required = false,
             Default = null,
             HelpText = "Path to deployment image file to be uploaded to device.")]
@@ -188,7 +189,21 @@ namespace nanoFramework.Tools.FirmwareFlasher
             HelpText = "Mass erase the device flash before uploading the firmware. If more than one file is specified to be flashed the mass erase will be performed before the first file is flashed.")]
         public bool MassErase { get; set; }
 
+        [Option(
+            "address",
+            Required = false,
+            HelpText = "Address(es) where to flash the BIN file(s). Hexadecimal format (e.g. 0x08000000). Required when specifying a BIN file with -binfile argument or flashing a deployment image with -deployment argument.")]
+        public IEnumerable<string> FlashAddress { get; set; }
+
+        [Option(
+            "reset",
+            Required = false,
+            Default = false,
+            HelpText = "Perform reset on connected device after all other requested operations are successfully performed.")]
+        public bool ResetMcu { get; set; }
+
         #endregion
+
 
         [Usage(ApplicationAlias = "nanoff")]
         public static IEnumerable<Example> Examples

--- a/source/nanoFirmwareFlasher/Stm32Operations.cs
+++ b/source/nanoFirmwareFlasher/Stm32Operations.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
@@ -15,8 +16,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
             string targetName,
             string fwVersion,
             bool stable,
+            bool updateFw,
             string applicationPath,
-            string applicationAddress,
+            string deploymentAddress,
             string dfuDeviceId,
             string jtagId,
             VerbosityLevel verbosity)
@@ -28,7 +30,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // if a target name wasn't specified use the default (and only available) ESP32 target
             if (string.IsNullOrEmpty(targetName))
             {
-                return ExitCodes.OK;
+                return ExitCodes.E1000;
             }
 
             Stm32Firmware firmware = new Stm32Firmware(
@@ -39,111 +41,148 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 Verbosity = verbosity
             };
 
-            var operationResult = await firmware.DownloadAndExtractAsync();
-            if (operationResult == ExitCodes.OK)
+            // need to download update package?
+            if (updateFw)
             {
+                var operationResult = await firmware.DownloadAndExtractAsync();
+                if (operationResult != ExitCodes.OK)
+                {
+                    return operationResult;
+                }
                 // download successful
+            }
 
-                // setup files to flash
-                var filesToFlash = new List<string>();
+            // setup files to flash
+            var filesToFlash = new List<string>();
 
+            if (updateFw)
+            {
                 filesToFlash.Add(firmware.nanoBooterFile);
                 filesToFlash.Add(firmware.nanoCLRFile);
+            }
 
-                // need to include application file?
-                if (!string.IsNullOrEmpty(applicationPath))
+            // need to include application file?
+            if (!string.IsNullOrEmpty(applicationPath))
+            {
+                // check application file
+                if (File.Exists(applicationPath))
                 {
-                    // check application file
-                    if (File.Exists(applicationPath))
+                    // check if application is BIN or HEX file
+                    if (Path.GetExtension(applicationPath) == "hex")
                     {
-                        // check if application is BIN or HEX file
-                        if (Path.GetExtension(applicationPath) == "hex")
-                        {
-                            // HEX we are good with adding it to the flash package
-                            filesToFlash.Add(new FileInfo(applicationPath).FullName);
-                        }
-                        else
-                        {
-                            // BIN app, set flag
-                            isApplicationBinFile = true;
-                        }
+                        // HEX we are good with adding it to the flash package
+                        filesToFlash.Add(new FileInfo(applicationPath).FullName);
                     }
                     else
                     {
-                        return ExitCodes.E9008;
-                    }
-                }
-
-                // need DFU or JTAG device
-                if (firmware.HasDfuPackage)
-                {
-                    // DFU package
-                    dfuDevice = new StmDfuDevice(dfuDeviceId);
-
-                    if (!dfuDevice.DevicePresent)
-                    {
-                        // no DFU device found
-
-                        // done here, this command has no further processing
-                        return ExitCodes.E1000;
-                    }
-
-                    if (verbosity >= VerbosityLevel.Normal)
-                    {
-                        Console.WriteLine($"Connected to DFU device with ID { dfuDevice.DeviceId }");
-                    }
-
-                    // set verbosity
-                    dfuDevice.Verbosity = verbosity;
-
-                    try
-                    {
-                        dfuDevice.FlashDfuFile(firmware.DfuPackage);
-
-                        // done here, this command has no further processing
-                        return ExitCodes.OK;
-                    }
-                    catch (Exception ex)
-                    {
-                        // exception
-                        return ExitCodes.E1003;
+                        // BIN app, set flag
+                        isApplicationBinFile = true;
                     }
                 }
                 else
                 {
-                    // JATG device
-                    jtagDevice = new StmJtagDevice(jtagId);
-
-                    if (!jtagDevice.DevicePresent)
-                    {
-                        // no JTAG device found
-
-                        // done here, this command has no further processing
-                        return ExitCodes.E5001;
-                    }
-
-                    if (verbosity >= VerbosityLevel.Normal)
-                    {
-                        Console.WriteLine($"Connected to JTAG device with ID { jtagDevice.DeviceId }");
-                    }
-
-                    // set verbosity
-                    jtagDevice.Verbosity = verbosity;
-
-                    // write files to flash
-                    var flashOperation = jtagDevice.FlashHexFiles(filesToFlash);
-
-                    if (flashOperation == ExitCodes.OK && isApplicationBinFile)
-                    {
-                        // now program the application file
-                        flashOperation = jtagDevice.FlashBinFiles(new List<string>() { applicationPath }, new List<string>() { applicationAddress });
-                    }
-
-                    return flashOperation;
+                    return ExitCodes.E9008;
                 }
             }
 
-            return ExitCodes.OK;
+            // need DFU or JTAG device
+            if (firmware.HasDfuPackage)
+            {
+                // DFU package
+                dfuDevice = new StmDfuDevice(dfuDeviceId);
+
+                if (!dfuDevice.DevicePresent)
+                {
+                    // no DFU device found
+
+                    // done here, this command has no further processing
+                    return ExitCodes.E1000;
+                }
+
+                if (verbosity >= VerbosityLevel.Normal)
+                {
+                    Console.WriteLine($"Connected to DFU device with ID { dfuDevice.DeviceId }");
+                }
+
+                // set verbosity
+                dfuDevice.Verbosity = verbosity;
+
+                try
+                {
+                    dfuDevice.FlashDfuFile(firmware.DfuPackage);
+
+                    // done here, this command has no further processing
+                    return ExitCodes.OK;
+                }
+                catch (Exception ex)
+                {
+                    // exception
+                    return ExitCodes.E1003;
+                }
+            }
+            else
+            {
+                // JATG device
+                jtagDevice = new StmJtagDevice(jtagId);
+
+                if (!jtagDevice.DevicePresent)
+                {
+                    // no JTAG device found
+
+                    // done here, this command has no further processing
+                    return ExitCodes.E5001;
+                }
+
+                if (verbosity >= VerbosityLevel.Normal)
+                {
+                    Console.WriteLine($"Connected to JTAG device with ID { jtagDevice.DeviceId }");
+                }
+
+                // set verbosity
+                jtagDevice.Verbosity = verbosity;
+
+                ExitCodes programResult = ExitCodes.OK;
+                // write HEX files to flash
+                if ( filesToFlash.Any(f => f.EndsWith(".hex")) ) 
+                {
+                    programResult = jtagDevice.FlashHexFiles(filesToFlash);
+                }
+
+                if (programResult == ExitCodes.OK && isApplicationBinFile)
+                {
+                    // now program the application file
+                    programResult = jtagDevice.FlashBinFiles(new List<string>() { applicationPath }, new List<string>() { deploymentAddress });
+                }
+
+                return programResult;
+            }
+        }
+
+        internal static ExitCodes ResetMcu(
+            string jtagId,
+            VerbosityLevel verbosity)
+        {
+            // JATG device
+            StmJtagDevice jtagDevice = new StmJtagDevice(jtagId);
+
+            if (!jtagDevice.DevicePresent)
+            {
+                // no JTAG device found
+
+                // done here, this command has no further processing
+                return ExitCodes.E5001;
+            }
+
+            if (verbosity >= VerbosityLevel.Normal)
+            {
+                Console.WriteLine($"Connected to JTAG device with ID { jtagDevice.DeviceId }");
+            }
+
+            // set verbosity
+            jtagDevice.Verbosity = verbosity;
+
+            // perform reset
+            return jtagDevice.ResetMcu();
         }
     }
 }

--- a/source/nanoFirmwareFlasher/StmJtagDevice.cs
+++ b/source/nanoFirmwareFlasher/StmJtagDevice.cs
@@ -307,7 +307,35 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             return jtagMatches.Cast<Match>().Select(i => i.Value).ToList();
         }
-        
+    
+        /// <summary>
+        /// Reset MCU of connected JTAG device.
+        /// </summary>
+        public ExitCodes ResetMcu()
+        {
+            // try to connect to device with RESET
+            var cliOuput = RunStLinkCli($"-c SN={DeviceId} UR");
+
+            if (!cliOuput.Contains("Connected via SWD."))
+            {
+                return ExitCodes.E5002;
+            }
+
+            if (Verbosity >= VerbosityLevel.Normal)
+            {
+                Console.Write("Reset MCU on device...");
+            }
+
+            cliOuput = RunStLinkCli("-Rst");
+
+            if (!cliOuput.Contains("MCU Reset."))
+            {
+                return ExitCodes.E5010;
+            }
+
+            return ExitCodes.OK;
+        }
+
         private static string RunStLinkCli(string arguments)
         {
             try

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1.0-preview.{height}",
+  "version": "1.2.0-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
- Both STM32 and ESP32 targets can now have the deployment image flash independently of updating the firmware.
- Rework Esp32Operations and Stm32Operation classes to support the above.
- Add feature to reset MCU on argument (SMT32 only).
- Move address argument to common group (was at STM32).
- Add new arguments to command line: deployment, reset
- Update argument is now false by default (so the deploy can be independent).
- Add new Exit codes to support new arguments.
- Bump version to 1.2.0-preview.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>