### PR TITLE
Fix ArgumentNullException when testing stm32 args

### DIFF
--- a/source/nanoFirmwareFlasher/Program.cs
+++ b/source/nanoFirmwareFlasher/Program.cs
@@ -192,7 +192,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 else if ( 
                     o.ListDevicesInDfuMode ||
                     !string.IsNullOrEmpty(o.DfuDeviceId) ||
-                    o.DfuFile.Any())
+                    !string.IsNullOrEmpty(o.DfuFile))
                 {
                     o.Platform = "stm32";
                 }


### PR DESCRIPTION
If none of these parameters are set in the command line :  
* listdfu  
* dfuid  
* dfufile  

the application will crash with an _ArgumentNullException_  
It is not even possible to launch the application in _esp32_ mode as the test fails just before