### PR TITLE
Remove buffer fill in dfu upload

### DIFF
--- a/source/nanoFirmwareFlasher/StDfu.cs
+++ b/source/nanoFirmwareFlasher/StDfu.cs
@@ -855,7 +855,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                         returnValue = STDFU_GetStatus(ref hDevice, ref dfuStatus);
                     }
 
-                    if (dfuStatus.bState != STDFU_NOERROR)
+                    if (returnValue != STDFU_NOERROR)
                     {
                         throw new DownloadException("STDFU_Dnload returned " + returnValue.ToString("X8"));
                     }
@@ -934,10 +934,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             returnValue = STDFU_Dnload(ref hDevice, data, (uint)data.Length, (ushort)(blockNumber + 2));
 
-            if (STDFU_GetStatus(ref hDevice, ref dfuStatus) != STATE_DFU_DOWNLOAD_BUSY)
+            STDFU_GetStatus(ref hDevice, ref dfuStatus);
+            if (dfuStatus.bState != STATE_DFU_DOWNLOAD_BUSY)
             {
                 throw new DownloadException("STDFU_Dnload returned " + returnValue.ToString("X8"));
-
             }
 
             while (dfuStatus.bState != STATE_DFU_IDLE)

--- a/source/nanoFirmwareFlasher/StmDfuDevice.cs
+++ b/source/nanoFirmwareFlasher/StmDfuDevice.cs
@@ -247,18 +247,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     // grab data for write and store it into a 2048 byte buffer
                     byte[] buffer = dfuElement.Data.Skip((int)(_maxWriteBlockSize * blockNumber)).Take(_maxWriteBlockSize).ToArray();
 
-                    if (buffer.Length < _maxWriteBlockSize)
-                    {
-                        var i = buffer.Length;
-                        Array.Resize(ref buffer, _maxWriteBlockSize);
-
-                        // Pad with 0xFF so our CRC matches the ST Bootloader and STLink's CRC
-                        for (; i < _maxWriteBlockSize; i++)
-                        {
-                            buffer[i] = 0xFF;
-                        }
-                    }
-
                     StDfu.WriteBlock(_hDevice, dfuElement.Address, buffer, blockNumber);
                 }
             }


### PR DESCRIPTION
- Filling the buffer to top the max packet length is breaking the write operation on non contiguous sectors.
- Return check on EraseSector was wrong.
- Resolves nanoframework/Home#555.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>