### PR TITLE
Fix ST devices that cannot handle DFU packages

### DIFF
--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -473,7 +473,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     return;
                 }
 
-                if (!string.IsNullOrEmpty(o.DfuFile))
+                var connectedStDfuDevices = StmDfuDevice.ListDfuDevices();
+                
+                if (!string.IsNullOrEmpty(o.DfuFile) && connectedStDfuDevices.Count != 0)
                 {
                     // there is a DFU file argument, so follow DFU path
                     var dfuDevice = new StmDfuDevice(o.DfuDeviceId);

--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -474,7 +474,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
 
                 var connectedStDfuDevices = StmDfuDevice.ListDfuDevices();
-                
+                var connectedStJtagDevices = StmJtagDevice.ListDevices();
+
                 if (!string.IsNullOrEmpty(o.DfuFile) && connectedStDfuDevices.Count != 0)
                 {
                     // there is a DFU file argument, so follow DFU path
@@ -524,7 +525,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
                 else if (
                     o.BinFile.Any() &&
-                    o.HexFile.Any())
+                    o.HexFile.Any() &&
+                    connectedStJtagDevices.Count != 0
+                     )
                 {
                     // this has to be a JTAG connected device
 

--- a/nanoFirmwareFlasher/Stm32Firmware.cs
+++ b/nanoFirmwareFlasher/Stm32Firmware.cs
@@ -40,11 +40,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     DfuPackage = dfuFile.FirstOrDefault();
                 }
-                else
-                {
-                    nanoBooterFile = Directory.EnumerateFiles(LocationPath, "nanoBooter.hex").FirstOrDefault();
-                    nanoCLRFile = Directory.EnumerateFiles(LocationPath, "nanoCLR.hex").FirstOrDefault();
-                }
+                nanoBooterFile = Directory.EnumerateFiles(LocationPath, "nanoBooter.hex").FirstOrDefault();
+                nanoCLRFile = Directory.EnumerateFiles(LocationPath, "nanoCLR.hex").FirstOrDefault();
             }
 
             return executionResult;

--- a/nanoFirmwareFlasher/Stm32Operations.cs
+++ b/nanoFirmwareFlasher/Stm32Operations.cs
@@ -85,8 +85,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
             }
 
+            var connectedStDfuDevices = StmDfuDevice.ListDfuDevices();
+            var connectedStJtagDevices = StmJtagDevice.ListDevices();
+
             // need DFU or JTAG device
-            if (firmware.HasDfuPackage)
+            if (firmware.HasDfuPackage && connectedStDfuDevices.Count !=0)
             {
                 // DFU package
                 dfuDevice = new StmDfuDevice(dfuDeviceId);
@@ -120,7 +123,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     return ExitCodes.E1003;
                 }
             }
-            else
+            else if (connectedStJtagDevices.Count != 0)
             {
                 // JATG device
                 jtagDevice = new StmJtagDevice(jtagId);
@@ -161,6 +164,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
 
                 return programResult;
+            }
+            else
+            {
+                // no device was found to update.
+                return ExitCodes.E7000;
             }
         }
 


### PR DESCRIPTION
## Description
Certain ST boards cannot handle DFU files out the box, even though they are created.
This changes the logic to check if a DFU (or JTAG) device is actually connected and acts accordingly.

## Motivation and Context
- Fixes nanoFramework/Home#719
- Fixes nanoFramework/Home#683

## How Has This Been Tested?
Locally against a few ST boards.

## Screenshots<!-- (if appropriate): -->
![image](https://user-images.githubusercontent.com/11439699/111051615-4a11e600-844c-11eb-8da8-7e6d016e609e.png)

![image](https://user-images.githubusercontent.com/11439699/111051594-1e8efb80-844c-11eb-88e1-fe7b0becf2fb.png)

![image](https://user-images.githubusercontent.com/11439699/111051560-e5568b80-844b-11eb-9632-81fb18ccf540.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
