### PR TITLE
Help option improvements for ESP32

### DIFF
--- a/nanoFirmwareFlasher/Options.cs
+++ b/nanoFirmwareFlasher/Options.cs
@@ -224,10 +224,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
             get
             {
                 return new List<Example>() {
-                    new Example("Update ESP32 device with latest fw (stable version)", new Options { TargetName = "ESP32_WROOM_32", Update = true, Stable = true }),
-                    new Example("Update ESP32 device with latest fw (stable version), device is connected to COM31", new Options { TargetName = "ESP32_WROOM_32", Update = true, Stable = true, SerialPort = "COM31" }),
-                    new Example("Update STM32 device with latest fw (development repository)", new Options { TargetName = "ST_STM32F769I_DISCOVERY" , Update = true}),
-                    new Example("Update STM32 device with latest fw (development repository), device is connected through DFU with Id 3380386D3134", new Options { TargetName = "NETDUINO3_WIFI",  Update = true, DfuDeviceId = "3380386D3134" }),
+                    new Example("Update ESP32 device with latest available firmware (nF org preview repository)", new Options { TargetName = "ESP32_WROOM_32" , Update = true}),
+                    new Example("Update ESP32 device with latest available firmware (nF org stable repository)", new Options { TargetName = "ESP32_WROOM_32", Update = true, Stable = true }),
+                    new Example("Update ESP32 device with latest available firmware (nF org stable repository), device is connected to COM31", new Options { TargetName = "ESP32_WROOM_32", Update = true, Stable = true, SerialPort = "COM31" }),
+                    new Example("Update ESP32 device with custom firmware (local bin file)", new Options { TargetName = "ESP32_WROOM_32" , DeploymentImage = "<location of file>.bin"}),
+                    new Example("Update STM32 device with latest available firmware (nF org preview repository)", new Options { TargetName = "ST_STM32F769I_DISCOVERY" , Update = true}),
+                    new Example("Update STM32 device with latest available firmware (nf org preview repository), device is connected through DFU with Id 3380386D3134", new Options { TargetName = "NETDUINO3_WIFI",  Update = true, DfuDeviceId = "3380386D3134" }),
                     new Example("List all STM32 devices connected through JTAG", new Options { Platform = "stm32", ListJtagDevices = true}),
                 };
             }

--- a/nanoFirmwareFlasher/Options.cs
+++ b/nanoFirmwareFlasher/Options.cs
@@ -228,7 +228,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     new Example("Update ESP32 device with latest available firmware (nF org stable repository)", new Options { TargetName = "ESP32_WROOM_32", Update = true, Stable = true }),
                     new Example("Update ESP32 device with latest available firmware (nF org stable repository), device is connected to COM31", new Options { TargetName = "ESP32_WROOM_32", Update = true, Stable = true, SerialPort = "COM31" }),
                     new Example("Update ESP32 device with custom firmware (local bin file)", new Options { TargetName = "ESP32_WROOM_32" , DeploymentImage = "<location of file>.bin"}),
-                    new Example("Update specific STM32 device (ST_STM32F769I_DISCOVERY) device with latest available firmware (nF org preview repository)", new Options { TargetName = "ST_STM32F769I_DISCOVERY" , Update = true}),
+                    new Example("Update specific STM32 device (ST_STM32F769I_DISCOVERY) with latest available firmware (nF org preview repository)", new Options { TargetName = "ST_STM32F769I_DISCOVERY" , Update = true}),
                     new Example("Update specific STM32 device (NETDUINO3_WIFI) with latest available firmware (nf org preview repository), device is connected through DFU with Id 3380386D3134", new Options { TargetName = "NETDUINO3_WIFI",  Update = true, DfuDeviceId = "3380386D3134" }),
                     new Example("List all STM32 devices connected through JTAG", new Options { Platform = "stm32", ListJtagDevices = true}),
                 };

--- a/nanoFirmwareFlasher/Options.cs
+++ b/nanoFirmwareFlasher/Options.cs
@@ -228,8 +228,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     new Example("Update ESP32 device with latest available firmware (nF org stable repository)", new Options { TargetName = "ESP32_WROOM_32", Update = true, Stable = true }),
                     new Example("Update ESP32 device with latest available firmware (nF org stable repository), device is connected to COM31", new Options { TargetName = "ESP32_WROOM_32", Update = true, Stable = true, SerialPort = "COM31" }),
                     new Example("Update ESP32 device with custom firmware (local bin file)", new Options { TargetName = "ESP32_WROOM_32" , DeploymentImage = "<location of file>.bin"}),
-                    new Example("Update STM32 device with latest available firmware (nF org preview repository)", new Options { TargetName = "ST_STM32F769I_DISCOVERY" , Update = true}),
-                    new Example("Update STM32 device with latest available firmware (nf org preview repository), device is connected through DFU with Id 3380386D3134", new Options { TargetName = "NETDUINO3_WIFI",  Update = true, DfuDeviceId = "3380386D3134" }),
+                    new Example("Update specific STM32 device (ST_STM32F769I_DISCOVERY) device with latest available firmware (nF org preview repository)", new Options { TargetName = "ST_STM32F769I_DISCOVERY" , Update = true}),
+                    new Example("Update specific STM32 device (NETDUINO3_WIFI) with latest available firmware (nf org preview repository), device is connected through DFU with Id 3380386D3134", new Options { TargetName = "NETDUINO3_WIFI",  Update = true, DfuDeviceId = "3380386D3134" }),
                     new Example("List all STM32 devices connected through JTAG", new Options { Platform = "stm32", ListJtagDevices = true}),
                 };
             }


### PR DESCRIPTION
## Description

## Motivation and Context
Loading local firmware to an ESP32 was hard to understand. This adds the appropriate command to do so.
It also improves the wording of other options to understand where firmware is located.

## How Has This Been Tested?

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
