### PR TITLE
Fix fwversion parameter not pulling the correct file

### DIFF
--- a/nanoFirmwareFlasher/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher/FirmwarePackage.cs
@@ -77,7 +77,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             // reference targets
             var repoName = _stable ? _refTargetsStableRepo : _refTargetsDevRepo;
-            string requestUri = $"{_cloudsmithPackages}/{repoName}/?page=1&query={_targetName} latest";
+            // get the firmware version if it is defined
+            var fwVersion = string.IsNullOrEmpty(_fwVersion) ? "latest" : _fwVersion;
+            string requestUri = $"{_cloudsmithPackages}/{repoName}/?page=1&query={_targetName} {fwVersion}";
 
             string downloadUrl = string.Empty;
 
@@ -157,7 +159,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                         }
 
                         // try with community targets
-                        requestUri = $"{_cloudsmithPackages}/{_communityTargetsepo}/?page=1&query={_targetName} latest";
+
+                        requestUri = $"{_cloudsmithPackages}/{_communityTargetsepo}/?page=1&query={_targetName} {fwVersion}";
                         repoName = _communityTargetsepo;
 
                         response = await _cloudsmithClient.GetAsync(requestUri);
@@ -186,10 +189,20 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     if (string.IsNullOrEmpty(_fwVersion))
                     {
                         _fwVersion = packageInfo.ElementAt(0).Version;
+                        // grab download URL
+                        downloadUrl = packageInfo.ElementAt(0).DownloadUrl;
+                    }
+                    else
+                    {
+                        //get the download Url from the Cloudsmith Package info
+                        // addition check if the cloudsmith json return empty json
+                        if(packageInfo is null || packageInfo.Count ==0)
+                            return ExitCodes.E9005;
+                        else
+                            downloadUrl = packageInfo.Where(w => w.Version == _fwVersion).Select(s => s.DownloadUrl).FirstOrDefault();
                     }
 
-                    // grab download URL
-                    downloadUrl = packageInfo.ElementAt(0).DownloadUrl;
+                   
 
                     // set exposed property
                     Version = _fwVersion;

--- a/nanoFirmwareFlasher/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher/FirmwarePackage.cs
@@ -196,10 +196,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     {
                         //get the download Url from the Cloudsmith Package info
                         // addition check if the cloudsmith json return empty json
-                        if(packageInfo is null || packageInfo.Count ==0)
-                            return ExitCodes.E9005;
+                        if(packageInfo is null || packageInfo.Count == 0)
+                        {    
+                           return ExitCodes.E9005;
+                        }
                         else
+                        {
                             downloadUrl = packageInfo.Where(w => w.Version == _fwVersion).Select(s => s.DownloadUrl).FirstOrDefault();
+                        }
                     }
 
                    


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Fix code to download fw package honoring --fwversion parameter, if supplied.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- It fixes the ability to download a specific version of the firmware.  

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
1) Delete the directory "c:\users\your_login_name\.nanoframework\ESP32_WROOM_32
2) run "nanoff  --target ESP32_WROOM_32 --serialport COM7 --fwversion 1.6.4-preview.183 --update"
3) Check the firmware version via Device Explorer (it should show FW version 1.6.4.183)
4) Delete the directory "c:\users\your_login_name\.nanoframework\ESP32_WROOM_32
5) run "nanoff  --target ESP32_WROOM_32 --serialport COM7  --update"
6) Check the firmware version via Device Explorer (it should show latest FW version)
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
