### PR TITLE
Add option to specify partition table size

### DIFF
--- a/nanoFirmwareFlasher/Esp32Firmware.cs
+++ b/nanoFirmwareFlasher/Esp32Firmware.cs
@@ -23,20 +23,29 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
         internal Dictionary<int, string> FlashPartitions;
 
+        internal PartitionTableSize? _partitionTableSize;
 
         /// <summary>
         /// Address of the deployment partition.
         /// </summary>
         internal int DeploymentPartionAddress =>  0x110000;
 
-        public Esp32Firmware(string targetName, string fwVersion, bool stable)
+        public Esp32Firmware(string targetName, string fwVersion, bool stable, PartitionTableSize? partitionTableSize)
             :base(targetName, fwVersion, stable)
         {
+            _partitionTableSize = partitionTableSize;
         }
 
         internal async System.Threading.Tasks.Task<ExitCodes> DownloadAndExtractAsync(int flashSize)
         {
-            string humanReadable = flashSize >= 0x10000 ? $"{ flashSize / 0x100000 }MB" : $"{ flashSize / 0x400 }kB";
+            if (_partitionTableSize is not null)
+            {
+                // if specified, partition table size overrides flash size.
+                flashSize = (int)_partitionTableSize * 0x100000;
+            }
+            var humanReadable = flashSize >= 0x10000 ? $"{ flashSize / 0x100000 }MB" : $"{ flashSize / 0x400 }kB";
+
+            // check if the option to override the partition table was set
 
             if (!SupportedFlashSizes.Contains(flashSize))
             {

--- a/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/nanoFirmwareFlasher/Esp32Operations.cs
@@ -89,6 +89,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             bool stable, 
             string applicationPath,
             string deploymentAddress,
+            PartitionTableSize? partitionTableSize,
             VerbosityLevel verbosity)
         {
             ExitCodes operationResult = ExitCodes.OK;
@@ -103,7 +104,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
             Esp32Firmware firmware = new Esp32Firmware(
                 targetName, 
                 fwVersion, 
-                stable)
+                stable,
+                partitionTableSize)
             {
                 Verbosity = verbosity
             };

--- a/nanoFirmwareFlasher/EspTool.cs
+++ b/nanoFirmwareFlasher/EspTool.cs
@@ -48,6 +48,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
         private readonly int _flashFrequency = 0;
 
         /// <summary>
+        /// Partition table size, when specified in the options.
+        /// </summary>
+        private readonly PartitionTableSize? _partitionTableSize = null;
+
+        /// <summary>
         /// The size of the flash in bytes; 4 MB = 0x40000 bytes
         /// </summary>
         private int _flashSize = -1;
@@ -149,11 +154,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="baudRate">The baud rate for the serial port.</param>
         /// <param name="flashMode">The flash mode for the esptool</param>
         /// <param name="flashFrequency">The flash frequency for the esptool</param>
+        /// <param name="partitionTableSize">Partition table size to use</param>
         internal EspTool(
             string serialPort, 
             int baudRate,
             string flashMode, 
-            int flashFrequency)
+            int flashFrequency,
+            PartitionTableSize? partitionTableSize)
         {
             // open/close the port to see if it is available
             using (SerialPort test = new SerialPort(serialPort, baudRate))
@@ -180,6 +187,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             _baudRate = baudRate;
             _flashMode = flashMode;
             _flashFrequency = flashFrequency;
+            _partitionTableSize = partitionTableSize;
         }
 
         /// <summary>

--- a/nanoFirmwareFlasher/Options.cs
+++ b/nanoFirmwareFlasher/Options.cs
@@ -98,6 +98,19 @@ namespace nanoFramework.Tools.FirmwareFlasher
             HelpText = "Flash frequency to use [MHz].")]
         public int Esp32FlashFrequency { get; set; }
 
+        /// <summary>
+        /// Allowed values:
+        /// 2
+        /// 4
+        /// 8
+        /// 16
+        /// </summary>
+        [Option(
+            "partitiontablesize",
+            Required = false,
+            Default = null,
+            HelpText = "Partition table size to use. Valid sizes are: 2, 4, 8 and 16.")]
+        public PartitionTableSize? Esp32PartitionTableSize { get; set; }
         #endregion
 
 
@@ -245,4 +258,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
         Diagnostic = 4
     }
 
+    public enum PartitionTableSize
+    {
+        _2 = 2,
+        _4 = 4,
+        _8 = 8,
+        _16 = 16,
+    }
 }

--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -229,7 +229,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                         o.SerialPort,
                         o.BaudRate,
                         o.Esp32FlashMode,
-                        o.Esp32FlashFrequency);
+                        o.Esp32FlashFrequency,
+                        o.Esp32PartitionTableSize);
                 }
                 catch(Exception)
                 {
@@ -314,6 +315,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                             o.Stable,
                             o.DeploymentImage,
                             null,
+                            o.Esp32PartitionTableSize,
                             verbosityLevel);
 
                         if (_exitCode != ExitCodes.OK)
@@ -373,6 +375,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                             false,
                             o.DeploymentImage,
                             appFlashAddress,
+                            o.Esp32PartitionTableSize,
                             verbosityLevel);
 
                         if (_exitCode != ExitCodes.OK)

--- a/nanoFirmwareFlasher/nanoFirmwareFlasher.csproj
+++ b/nanoFirmwareFlasher/nanoFirmwareFlasher.csproj
@@ -46,7 +46,7 @@
   
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.194" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.IO.Ports" Version="4.7.0" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description

If specified, the new option `partitiontablesize` overrides flash size.

It's useful for ESP32 devices with flash size of 16MB and 32MB. Their firmware currently has a bug and doesn't work unless you write it to the device as if it had 4MB flash size.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes/closes/resolves an open issue, please link to the issue here using the template bellow (mind the link as all issues are open in the Home repository, not in this one) -->

Currently NanoFramework doesn't work with ESP32 device (M5Stack) with 16MB flash size.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
