### PR TITLE
Correct the way nanoff chooses the partition to erase.

### DIFF
--- a/nanoFirmwareFlasher/Esp32Firmware.cs
+++ b/nanoFirmwareFlasher/Esp32Firmware.cs
@@ -21,6 +21,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// </summary>
         internal List<int> SupportedFlashSizes => new List<int> { 0x200000, 0x400000, 0x800000, 0x1000000 };
 
+        internal string BootloaderPath;
+
         internal Dictionary<int, string> FlashPartitions;
 
 
@@ -53,11 +55,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             if (executionResult == ExitCodes.OK)
             {
+                BootloaderPath = "bootloader.bin";
+                
                 // get ESP32 partitions
                 FlashPartitions = new Dictionary<int, string>()
                 {
 				    // bootloader goes to 0x1000
-				    { 0x1000, Path.Combine(LocationPath, "bootloader.bin") },
+				    { 0x1000, Path.Combine(LocationPath, BootloaderPath) },
 
 				    // nanoCLR goes to 0x10000
 				    { 0x10000, Path.Combine(LocationPath, "nanoCLR.bin") },

--- a/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/nanoFirmwareFlasher/Esp32Operations.cs
@@ -168,9 +168,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 // need to get deployment address here
                 // length must both be multiples of the SPI flash erase sector size. This is 0x1000 (4096) bytes for supported flash chips.
 
-                var flashPartition = firmware.FlashPartitions.First();
-
-                var fileStream = File.OpenRead(flashPartition.Value);
+                var fileStream = File.OpenRead(firmware.BootloaderPath);
 
                 uint fileLength = (uint)Math.Ceiling((decimal)fileStream.Length / 0x1000) * 0x1000;
 


### PR DESCRIPTION
## Description

FlashPartitions.First returned a random flash partition because FlashPartitions is a dictionary. 
It was expected that it returns the partition with the lowest offset.

## How Has This Been Tested?<!-- (if applicable) -->

Not tested.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
