### PR TITLE
Fix allowing spaces in username folder path

### DIFF
--- a/nanoFirmwareFlasher/StmJtagDevice.cs
+++ b/nanoFirmwareFlasher/StmJtagDevice.cs
@@ -62,9 +62,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
             else
             {
                 // JTAG id supplied, try to connect to device to check availability
-                var cliOuput = RunStLinkCli($"-c SN={jtagId} HOTPLUG");
+                var cliOutput = RunStLinkCli($"-c SN={jtagId} HOTPLUG");
 
-                if (!cliOuput.Contains("Connected via SWD."))
+                if (!cliOutput.Contains("Connected via SWD."))
                 {
                     throw new CantConnectToJtagDeviceException();
                 }
@@ -90,9 +90,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
 
             // try to connect to device with RESET
-            var cliOuput = RunStLinkCli($"-c SN={DeviceId} UR");
+            var cliOutput = RunStLinkCli($"-c SN={DeviceId} UR");
 
-            if (!cliOuput.Contains("Connected via SWD."))
+            if (!cliOutput.Contains("Connected via SWD."))
             {
                 return ExitCodes.E5002;
             }
@@ -105,9 +105,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     Console.Write("Mass erase device...");
                 }
 
-                cliOuput = RunStLinkCli($"-c SN={DeviceId} UR -ME");
+                cliOutput = RunStLinkCli($"-c SN={DeviceId} UR -ME");
 
-                if (!cliOuput.Contains("Flash memory erased."))
+                if (!cliOutput.Contains("Flash memory erased."))
                 {
                     return ExitCodes.E5005;
                 }
@@ -142,9 +142,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     Console.WriteLine($"{Path.GetFileName(hexFile)}");
                 }
 
-                cliOuput = RunStLinkCli($"-c SN={DeviceId} UR -Q -P {hexFile}");
+                cliOutput = RunStLinkCli($"-c SN={DeviceId} UR -Q -P \"{hexFile}\"");
 
-                if (!cliOuput.Contains("Programming Complete."))
+                if (!cliOutput.Contains("Programming Complete."))
                 {
                     return ExitCodes.E5006;
                 }
@@ -211,9 +211,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
 
             // try to connect to device with RESET
-            var cliOuput = RunStLinkCli($"-c SN={DeviceId} UR");
+            var cliOutput = RunStLinkCli($"-c SN={DeviceId} UR");
 
-            if (!cliOuput.Contains("Connected via SWD."))
+            if (!cliOutput.Contains("Connected via SWD."))
             {
                 return ExitCodes.E5002;
             }
@@ -226,9 +226,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     Console.Write("Mass erase device...");
                 }
 
-                cliOuput = RunStLinkCli($"-c SN={DeviceId} UR -ME");
+                cliOutput = RunStLinkCli($"-c SN={DeviceId} UR -ME");
 
-                if (!cliOuput.Contains("Flash memory erased."))
+                if (!cliOutput.Contains("Flash memory erased."))
                 {
                     Console.WriteLine("");
                     return ExitCodes.E5005;
@@ -265,9 +265,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     Console.WriteLine($"{Path.GetFileName(binFile)} @ {addresses.ElementAt(index)}");
                 }
 
-                cliOuput = RunStLinkCli($"-c SN={DeviceId} UR -Q -P {binFile} {addresses.ElementAt(index++)}");
+                cliOutput = RunStLinkCli($"-c SN={DeviceId} UR -Q -P \"{binFile}\" {addresses.ElementAt(index++)}");
 
-                if (!cliOuput.Contains("Programming Complete."))
+                if (!cliOutput.Contains("Programming Complete."))
                 {
                     return ExitCodes.E5006;
                 }
@@ -291,7 +291,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <returns>A collection of connected STM JTAG devices.</returns>
         public static List<string> ListDevices()
         {
-            var cliOuput = RunStLinkCli("-List");
+            var cliOutput = RunStLinkCli("-List");
 
             // (successful) output from the above is
             //
@@ -311,7 +311,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             string regexPattern = @"(?<=SN:\s)(?<serial>.{24})";
 
             var myRegex1 = new Regex(regexPattern, RegexOptions.Multiline);
-            var jtagMatches = myRegex1.Matches(cliOuput);
+            var jtagMatches = myRegex1.Matches(cliOutput);
 
             if(jtagMatches.Count == 0)
             {
@@ -328,9 +328,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
         public ExitCodes ResetMcu()
         {
             // try to connect to device with RESET
-            var cliOuput = RunStLinkCli($"-c SN={DeviceId} UR");
+            var cliOutput = RunStLinkCli($"-c SN={DeviceId} UR");
 
-            if (!cliOuput.Contains("Connected via SWD."))
+            if (!cliOutput.Contains("Connected via SWD."))
             {
                 return ExitCodes.E5002;
             }
@@ -340,9 +340,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 Console.Write("Reset MCU on device...");
             }
 
-            cliOuput = RunStLinkCli("-Rst");
+            cliOutput = RunStLinkCli("-Rst");
 
-            if (!cliOuput.Contains("MCU Reset."))
+            if (!cliOutput.Contains("MCU Reset."))
             {
                 Console.WriteLine("");
                 return ExitCodes.E5010;


### PR DESCRIPTION
When using nanoff (v1.20.0-preview.8) for a STM32 development board (in my case a STM32F429I-DISCOVERY) the firmware update fails. 

This is because the command line argument for the utility ST-LINK_CLI.exe that contains the path to the file to be programmed has a space in it and it is not quoted. The firmware files are automatically downloaded by nanoff and put in a directory under the users folder. In this case the Windows 10 username has a space in it and therefore the full path name to the firmware file has a space in it. 

The fix is to quote the path/filename for the argument to ST-LINK_CLI.exe

Also fixed a variable name typo at the same time.

## Description
There are 2 calls to ST-LINK_CLI.exe that use the full path/filename to the firmware files that are automatically downloaded. One for hex files and the other for binary files.

Add quotes around the path/filename argument for these calls.

Also fixed a typo cliOuput to cliOutput 

## Motivation and Context
Fixes nanoff firmware update when Windows 10 username has a space in it.

An issue was not created since this change is trivial.

## How Has This Been Tested?
Tested firmware update when a Windows 10 username has a space in it.
Windows 10 Pro, Version 20H2, OS build 19042.1052

Did not test on any other platforms.
Change isolated to STM targets, does not effect ESP or TI.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
