### PR TITLE
Add support to flash ESP32 with a local CLR image

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,23 @@ The tool includes help for all available commands. You can see a list of all ava
 nanoff --help
 ```
 
+## ESP32 usage examples 
+
 ### Update the firmware of an ESP32_WROOM_32 target
 
 To update the firmware of an ESP32_WROOM_32 target connected to COM31, to the latest available development version.
 
 ```console
 nanoff --update --target ESP32_WROOM_32 --serialport COM31
+```
+
+### Update the firmware of an ESP32_WROOM_32 target with a local CLR file
+
+To update the firmware of an ESP32_WROOM_32 target connected to COM31 with a local CLR file (for example from a build).
+This file has to be a binary file with a valid CLR from a build. No other checks or validations are performed on the file content.
+
+```console
+nanoff --update --target ESP32_WROOM_32 --serialport COM31 --clrfile "C:\nf-interpreter\build\nanoCLR.bin" 
 ```
 
 ### Deploy a managed application to an ESP32_WROOM_32 target
@@ -85,6 +96,8 @@ This example uses the binary format file that was saved on a previous backup ope
 ```console
 nanoff --update --target ESP32_WROOM_32 --serialport COM31 --deployment "c:\eps32-backups\my_awesome_app.bin"
 ```
+
+## STMP32 usage examples 
 
 ### Update the firmware of a specific STM32 target
 
@@ -145,6 +158,8 @@ To install the drivers for STM32 DFU connected targets.
 ```console
 nanoff --installdfudrivers
 ```
+
+## TI CC13x2 usage examples 
 
 ### Update the firmware of a specific TI CC13x2 target
 

--- a/nanoFirmwareFlasher/Esp32Firmware.cs
+++ b/nanoFirmwareFlasher/Esp32Firmware.cs
@@ -17,6 +17,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
     internal class Esp32Firmware : FirmwarePackage
     {
         /// <summary>
+        /// Address of the CLR partition.
+        /// </summary>
+        public const int CLRAddress = 0x10000;
+
+        /// <summary>
         /// ESP32 nanoCLR is available for 2MB, 4MB, 8MB and 16MB flash sizes
         /// </summary>
         private List<int> SupportedFlashSizes => new() { 0x200000, 0x400000, 0x800000, 0x1000000 };
@@ -80,7 +85,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 				    { 0x1000, Path.Combine(LocationPath, BootloaderPath) },
 
 				    // nanoCLR goes to 0x10000
-				    { 0x10000, Path.Combine(LocationPath, "nanoCLR.bin") },
+				    { CLRAddress, Path.Combine(LocationPath, "nanoCLR.bin") },
 
 				    // partition table goes to 0x8000; there are partition tables for 2MB, 4MB, 8MB and 16MB flash sizes
 				    { 0x8000, Path.Combine(LocationPath, $"partitions_{humanReadable.ToLowerInvariant()}.bin") }

--- a/nanoFirmwareFlasher/EspTool.cs
+++ b/nanoFirmwareFlasher/EspTool.cs
@@ -302,11 +302,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 throw new EraseEsp32FlashException(messages);
             }
 
-            if (Verbosity >= VerbosityLevel.Detailed)
-            {
-                Console.WriteLine(match.Groups["message"].ToString().Trim());
-            }
-
             return ExitCodes.OK;
         }
 

--- a/nanoFirmwareFlasher/ExitCodes.cs
+++ b/nanoFirmwareFlasher/ExitCodes.cs
@@ -242,5 +242,17 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// </summary>
         [Display(Name = "Couldn't find any device connected.")]
         E9010 = 9010,
+
+        /// <summary>
+        /// Couldn't find CLR image file. Check the path.
+        /// </summary>
+        [Display(Name = "Couldn't find CLR image file. Check the path.")]
+        E9011 = 9011,
+
+        /// <summary>
+        /// CLR image file has wrong format. It has to be a binary file.
+        /// </summary>
+        [Display(Name = "CLR image file has wrong format.It has to be a binary file.")]
+        E9012 = 9012,
     }
 }

--- a/nanoFirmwareFlasher/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher/FirmwarePackage.cs
@@ -365,9 +365,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
             }
 
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine($"Updating to {Version}");
-            Console.ForegroundColor = ConsoleColor.White;
+            if (Verbosity >= VerbosityLevel.Normal)
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine($"Updating to {Version}");
+                Console.ForegroundColor = ConsoleColor.White;
+            }
 
             return ExitCodes.OK;
         }

--- a/nanoFirmwareFlasher/Options.cs
+++ b/nanoFirmwareFlasher/Options.cs
@@ -139,10 +139,18 @@ namespace nanoFramework.Tools.FirmwareFlasher
             Default = null,
             HelpText = "Partition table size to use. Valid sizes are: 2, 4, 8 and 16.")]
         public PartitionTableSize? Esp32PartitionTableSize { get; set; }
+
+        [Option(
+            "clrfile",
+            Required = false,
+            Default = null,
+            HelpText = "Path to file with CLR image. Partitions table and bootloader file will be automatically flashed to the device.")]
+        public string Esp32ClrFile { get; set; }
+
         #endregion
 
 
-        # region TI options
+        #region TI options
 
 
         [Option(

--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -237,7 +237,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     !string.IsNullOrEmpty(o.SerialPort) ||
                     (o.BaudRate != 921600) ||
                     (o.Esp32FlashMode != "dio") ||
-                    (o.Esp32FlashFrequency != 40))
+                    (o.Esp32FlashFrequency != 40) ||
+                    !string.IsNullOrEmpty(o.Esp32ClrFile))
                 {
                     o.Platform = "esp32";
                 }
@@ -361,8 +362,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                             o.Preview,
                             o.DeploymentImage,
                             null,
-                            o.Esp32PartitionTableSize,
-                            _verbosityLevel);
+                            o.Esp32ClrFile,
+                            _verbosityLevel,
+                            o.Esp32PartitionTableSize);
 
                         if (_exitCode != ExitCodes.OK)
                         {
@@ -421,8 +423,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                             false,
                             o.DeploymentImage,
                             appFlashAddress,
-                            o.Esp32PartitionTableSize,
-                            _verbosityLevel);
+                            null,
+                            _verbosityLevel,
+                            o.Esp32PartitionTableSize);
 
                         if (_exitCode != ExitCodes.OK)
                         {


### PR DESCRIPTION
## Description
- Add new option.
- Update validations.
- Update ESP32 firmware file to support this workflow.
- Add usage sample to README.
- Update formating on the README to make it more readable.

## Motivation and Context
- Need to be able to flash an ESP32 target with a local CLR file, handling the bootloader and the partition tables automatically.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
