### PR TITLE
Set Cloudsmith query to strict target name

### DIFF
--- a/nanoFirmwareFlasher/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher/FirmwarePackage.cs
@@ -82,7 +82,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             var repoName = _preview ? _refTargetsDevRepo : _refTargetsStableRepo;
             // get the firmware version if it is defined
             var fwVersion = string.IsNullOrEmpty(_fwVersion) ? "latest" : _fwVersion;
-            string requestUri = $"{_cloudsmithPackages}/{repoName}/?page=1&query={_targetName} {fwVersion}";
+            string requestUri = $"{_cloudsmithPackages}/{repoName}/?page=1&query=^{_targetName}$ {fwVersion}";
 
             string downloadUrl = string.Empty;
 
@@ -182,7 +182,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                         // try with community targets
 
-                        requestUri = $"{_cloudsmithPackages}/{_communityTargetsRepo}/?page=1&query={_targetName} {fwVersion}";
+                        requestUri = $"{_cloudsmithPackages}/{_communityTargetsRepo}/?page=1&query=^{_targetName}$ {fwVersion}";
 
                         response = await _cloudsmithClient.GetAsync(requestUri);
 


### PR DESCRIPTION
## Description
Force the Cloudsmith request to only return a specific target name instead of using a loose query.

## Motivation and Context
The Cloudsmith request resulted in multiple results when querying on e.g. `ESP32_WROOM_32`, which could cause the wrong version to be flashed, like `ESP32_WROOM_32_BL`.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Debug the command and inspect the returned results.
- Run the command with `--target ESP32_WROOM_32`, confirm with VS extension "capabilities" button that device has the requested target.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
