### PR TITLE
Output help message when no operation was performed

### DIFF
--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -889,8 +889,25 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
             }
 
-#endregion
+            #endregion
 
+            // done nothing...
+            // because of short-comings in CommandLine parsing 
+            // need to customize the output to provide a consistent output
+            var parser = new Parser(config => config.HelpWriter = null);
+            var result = parser.ParseArguments<Options>(new[] { "", "" });
+
+            var helpText = new HelpText(
+                new HeadingInfo(_headerInfo),
+                _copyrightInfo)
+                    .AddPreOptionsLine("")
+                    .AddPreOptionsLine("No operation was performed with the options supplied.")
+                    .AddPreOptionsLine("")
+                    .AddPreOptionsLine(HelpText.RenderUsageText(result))
+                    .AddPreOptionsLine("")
+                    .AddOptions(result);
+
+            Console.WriteLine(helpText.ToString());
         }
 
         private static void OutputError(ExitCodes errorCode, bool outputMessage, string extraMessage = null)


### PR DESCRIPTION
## Description
- Help message is now show when no operation is performed.

## Motivation and Context
- Missing or wrong options combination can lead to an execution path on which the tool doesn't perform any operation at all. Until now that would cause the tool to exit without any information about it which could be confusing to the user. Now a information message about this is show along with the standard help output.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
