### PR TITLE
Fix execution of STM32 mass erase as standalone operation

### DIFF
--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -781,12 +781,27 @@ namespace nanoFramework.Tools.FirmwareFlasher
                                         o.JtagDeviceId,
                                         _verbosityLevel);
 
-                        if (_exitCode != ExitCodes.OK)
-                        {
-                            // done here
-                            return;
-                        }
+                        // done here
+                        return;
                     }
+                }
+                else if(o.MassErase)
+                {
+                    _exitCode = Stm32Operations.MassErase(
+                                    o.JtagDeviceId,
+                                    _verbosityLevel);
+
+                    // done here
+                    return;
+                }
+                else if (o.ResetMcu)
+                {
+                    _exitCode = Stm32Operations.ResetMcu(
+                                    o.JtagDeviceId,
+                                    _verbosityLevel);
+
+                    // done here
+                    return;
                 }
             }
 

--- a/nanoFirmwareFlasher/Stm32Operations.cs
+++ b/nanoFirmwareFlasher/Stm32Operations.cs
@@ -247,6 +247,33 @@ namespace nanoFramework.Tools.FirmwareFlasher
             return jtagDevice.ResetMcu();
         }
 
+        internal static ExitCodes MassErase(
+            string jtagId,
+            VerbosityLevel verbosity)
+        {
+            // JATG device
+            StmJtagDevice jtagDevice = new StmJtagDevice(jtagId);
+
+            if (!jtagDevice.DevicePresent)
+            {
+                // no JTAG device found
+
+                // done here, this command has no further processing
+                return ExitCodes.E5001;
+            }
+
+            if (verbosity >= VerbosityLevel.Normal)
+            {
+                Console.WriteLine($"Connected to JTAG device with ID { jtagDevice.DeviceId }");
+            }
+
+            // set verbosity
+            jtagDevice.Verbosity = verbosity;
+
+            // perform erase operation
+            return jtagDevice.MassErase();
+        }
+
         internal static ExitCodes InstallDfuDrivers(VerbosityLevel verbosityLevel)
         {
             try

--- a/nanoFirmwareFlasher/StmJtagDevice.cs
+++ b/nanoFirmwareFlasher/StmJtagDevice.cs
@@ -96,30 +96,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // erase flash
             if (DoMassErase)
             {
-                if (Verbosity >= VerbosityLevel.Normal)
-                {
-                    Console.ForegroundColor = ConsoleColor.White;
-                    Console.Write("Mass erase device...");
-                }
+                var eraseResult = MassErase();
 
-                cliOutput = RunSTM32ProgrammerCLI($"-c port=SWD sn={DeviceId} mode=UR -e all");
-
-                if (!cliOutput.Contains("Flash memory erased."))
+                if (eraseResult != ExitCodes.OK)
                 {
-                    return ExitCodes.E5005;
+                    return eraseResult;
                 }
-
-                if (Verbosity >= VerbosityLevel.Normal)
-                {
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine(" OK");
-                }
-                else
-                {
-                    Console.ForegroundColor = ConsoleColor.White;
-                    Console.WriteLine("");
-                }
-                Console.ForegroundColor = ConsoleColor.White;
 
                 // toggle mass erase so it's only performed before the first file is flashed
                 DoMassErase = false;
@@ -221,31 +203,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // erase flash
             if (DoMassErase)
             {
-                if (Verbosity >= VerbosityLevel.Normal)
-                {
-                    Console.ForegroundColor = ConsoleColor.White;
-                    Console.Write("Mass erase device...");
-                }
+                var eraseResult = MassErase();
 
-                cliOutput = RunSTM32ProgrammerCLI($"-c port=SWD sn={DeviceId} mode=UR -e all");
-
-                if (!cliOutput.Contains("Flash memory erased."))
+                if (eraseResult != ExitCodes.OK)
                 {
-                    Console.ForegroundColor = ConsoleColor.Red;
-                    Console.WriteLine("ERROR");
-                    return ExitCodes.E5005;
+                    return eraseResult;
                 }
-
-                if (Verbosity >= VerbosityLevel.Normal)
-                {
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine(" OK");
-                }
-                else
-                {
-                    Console.WriteLine("");
-                }
-                Console.ForegroundColor = ConsoleColor.White;
 
                 // toggle mass erase so it's only performed before the first file is flashed
                 DoMassErase = false;
@@ -361,6 +324,42 @@ namespace nanoFramework.Tools.FirmwareFlasher
             else
             {
                 Console.ForegroundColor = ConsoleColor.White;
+                Console.WriteLine("");
+            }
+
+            Console.ForegroundColor = ConsoleColor.White;
+
+            return ExitCodes.OK;
+        }
+
+
+        /// <summary>
+        /// Reset MCU of connected JTAG device.
+        /// </summary>
+        public ExitCodes MassErase()
+        {
+            if (Verbosity >= VerbosityLevel.Normal)
+            {
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write("Mass erase device...");
+            }
+
+            var cliOutput = RunSTM32ProgrammerCLI($"-c port=SWD sn={DeviceId} mode=UR -e all");
+
+            if (!cliOutput.Contains("Mass erase successfully achieved"))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("ERROR");
+                return ExitCodes.E5005;
+            }
+
+            if (Verbosity >= VerbosityLevel.Normal)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine(" OK");
+            }
+            else
+            {
                 Console.WriteLine("");
             }
 


### PR DESCRIPTION
## Description
- Implement MassErase operation at StmJtagDevice.
- Implement MassErase operation at StmJtagDevice.
- Rework code to use this new method instead of repeating code inside.
- Rework initial execution path to allow execution of MassErase and Reset device as standalone operations.

## Motivation and Context
- Allow allow execution of MassErase and Reset device as standalone operations.
- Remove duplicated code staying DRY.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
