### PR TITLE
Fix help message showing despite operation executed

### DIFF
--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -121,6 +121,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
         static async Task RunOptionsAndReturnExitCodeAsync(Options o)
         {
+            bool operationPerformed = false;
+
             #region parse verbosity option
 
             switch (o.Verbosity)
@@ -333,11 +335,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     {
                         // backup path specified, backup deployment
                         _exitCode = Esp32Operations.BackupFlash(espTool, esp32Device, o.BackupPath, o.BackupFile, _verbosityLevel);
+                        
                         if (_exitCode != ExitCodes.OK)
                         {
                             // done here
                             return;
                         }
+
+                        operationPerformed = true;
                     }
                     catch (ReadEsp32FlashException ex)
                     {
@@ -470,22 +475,16 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     _exitCode = Stm32Operations.InstallDfuDrivers(_verbosityLevel);
 
-                    if (_exitCode != ExitCodes.OK)
-                    {
-                        // done here
-                        return;
-                    }
+                    // done here
+                    return;
                 }
 
                 if (o.InstallJtagDrivers)
                 {
                     _exitCode = Stm32Operations.InstallJtagDrivers(_verbosityLevel);
 
-                    if (_exitCode != ExitCodes.OK)
-                    {
-                        // done here
-                        return;
-                    }
+                    // done here
+                    return;
                 }
 
                 if (o.ListDevicesInDfuMode)
@@ -712,6 +711,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                             updateInterface,
                             _verbosityLevel);
 
+                        operationPerformed = true;
+
                         if (_exitCode != ExitCodes.OK)
                         {
                             // done here
@@ -767,6 +768,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                                         updateInterface,
                                         _verbosityLevel);
 
+                        operationPerformed = true;
+
                         if (_exitCode != ExitCodes.OK)
                         {
                             // done here
@@ -814,14 +817,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
             {
                 if (o.TIInstallXdsDrivers)
                 {
-
                     _exitCode = CC13x26x2Operations.InstallXds110Drivers(_verbosityLevel);
 
-                    if (_exitCode != ExitCodes.OK)
-                    {
-                        // done here
-                        return;
-                    }
+                    // done here
+                    return;
                 }
 
                 if (!string.IsNullOrEmpty(o.TargetName))
@@ -848,6 +847,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                             o.DeploymentImage,
                             appFlashAddress,
                             _verbosityLevel);
+
+                        operationPerformed = true;
 
                         if (_exitCode != ExitCodes.OK)
                         {
@@ -884,6 +885,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                                         appFlashAddress,
                                         _verbosityLevel);
 
+                        operationPerformed = true;
+
                         if (_exitCode != ExitCodes.OK)
                         {
                             // done here
@@ -906,23 +909,26 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             #endregion
 
-            // done nothing...
-            // because of short-comings in CommandLine parsing 
-            // need to customize the output to provide a consistent output
-            var parser = new Parser(config => config.HelpWriter = null);
-            var result = parser.ParseArguments<Options>(new[] { "", "" });
+            // done nothing... or maybe not...
+            if (!operationPerformed)
+            {
+                // because of short-comings in CommandLine parsing 
+                // need to customize the output to provide a consistent output
+                var parser = new Parser(config => config.HelpWriter = null);
+                var result = parser.ParseArguments<Options>(new[] { "", "" });
 
-            var helpText = new HelpText(
-                new HeadingInfo(_headerInfo),
-                _copyrightInfo)
-                    .AddPreOptionsLine("")
-                    .AddPreOptionsLine("No operation was performed with the options supplied.")
-                    .AddPreOptionsLine("")
-                    .AddPreOptionsLine(HelpText.RenderUsageText(result))
-                    .AddPreOptionsLine("")
-                    .AddOptions(result);
+                var helpText = new HelpText(
+                    new HeadingInfo(_headerInfo),
+                    _copyrightInfo)
+                        .AddPreOptionsLine("")
+                        .AddPreOptionsLine("No operation was performed with the options supplied.")
+                        .AddPreOptionsLine("")
+                        .AddPreOptionsLine(HelpText.RenderUsageText(result))
+                        .AddPreOptionsLine("")
+                        .AddOptions(result);
 
-            Console.WriteLine(helpText.ToString());
+                Console.WriteLine(helpText.ToString());
+            }
         }
 
         private static void OutputError(ExitCodes errorCode, bool outputMessage, string extraMessage = null)

--- a/nanoFirmwareFlasher/Stm32Operations.cs
+++ b/nanoFirmwareFlasher/Stm32Operations.cs
@@ -210,7 +210,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     programResult = jtagDevice.FlashBinFiles(new [] { applicationPath }, new [] { deploymentAddress });
                 }
 
-                if(updateFw)
+                if(
+                    updateFw 
+                    && programResult == ExitCodes.OK)
                 {
                     // reset MCU
                     jtagDevice.ResetMcu();


### PR DESCRIPTION
## Description
- Add local to track if any operation was executed before showing help message.
- The reset operation on an update was being performed despite the failure of the previous ones.

## Motivation and Context
- On some workflows when one of the operation in a sequence failed, the help message was being displayed like if any operation had been executed. Despite the appropriate error message is wrongly states that no operation was executed. On top of that because all the output the actual and relevant message could be easily missed by the user. 
- Need to improve user experience.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
