### PR TITLE
Fix output message on ESP32 sanity check

### DIFF
--- a/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/nanoFirmwareFlasher/Esp32Operations.cs
@@ -127,10 +127,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 // trying to use a target that's not compatible with the connected device 
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("");
-                Console.WriteLine("************************************** WARNING *************************************");
+                Console.WriteLine("***************************************** WARNING ****************************************");
                 Console.WriteLine("Seems that you're about to use a firmware image for a revision 3 device, but the");
                 Console.WriteLine($"connected device is {esp32Device.ChipName}. You should use the 'ESP32_WROOM_32' instead.");
-                Console.WriteLine("************************************************************************************");
+                Console.WriteLine("******************************************************************************************");
                 Console.WriteLine("");
             }
 
@@ -140,10 +140,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 // trying to use a traget with BT and the connected device doens't have support for it
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("");
-                Console.WriteLine("************************************** WARNING *************************************");
+                Console.WriteLine("******************************************* WARNING ********************************************");
                 Console.WriteLine("Seems that you're about to use a firmware image that includes Bluetooth, but the");
-                Console.WriteLine($"connected device does have support for it. You should use a target without BLE in the name");
-                Console.WriteLine("************************************************************************************");
+                Console.WriteLine($"connected device does not have support for it. You should use a target without BLE in the name.");
+                Console.WriteLine("************************************************************************************************");
                 Console.WriteLine("");
             }
 


### PR DESCRIPTION
## Description
- Fix output message on ESP32 sanity check.

## Motivation and Context
- Message wasn't coherent.
- Output wasn't properly formatted.
- Closes nanoFramework/Home#806.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
