### PR TITLE
Improve flashing STM32 with JTAG

### DIFF
--- a/nanoFirmwareFlasher/StmJtagDevice.cs
+++ b/nanoFirmwareFlasher/StmJtagDevice.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
@@ -99,6 +100,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
             {
                 return ExitCodes.E5003;
             }
+
+            // need a couple of seconds before issuing next command
+            Thread.Sleep(2000);
 
             // try to connect to device with RESET
             var cliOutput = RunSTM32ProgrammerCLI($"-c port=SWD sn={DeviceId} mode=NORMAL");
@@ -229,8 +233,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
             }
 
+            // need a couple of seconds before issuing next command
+            Thread.Sleep(2000);
+
             // try to connect to device with RESET
-            var cliOutput = RunSTM32ProgrammerCLI($"-c port=SWD sn={DeviceId} mode=UR");
+            var cliOutput = RunSTM32ProgrammerCLI($"-c port=SWD sn={DeviceId} mode=NORMAL");
 
             if (!cliOutput.Contains("Connected via SWD."))
             {


### PR DESCRIPTION
## Description
- Add sleep before connecting to device.

## Motivation and Context
- On some slower devices the commands where being issued too fast and ST-Link was having trouble listing the device before the flash operation.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
