### PR TITLE
Fix for ESP32_PICO firmware update

### DIFF
--- a/nanoFirmwareFlasher/EspTool.cs
+++ b/nanoFirmwareFlasher/EspTool.cs
@@ -123,7 +123,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// Tries reading ESP32 device details.
         /// </summary>
         /// <returns>The filled info structure with all the information about the connected ESP32 device or null if an error occured</returns>
-        internal Esp32DeviceInfo GetDeviceDetails()
+        internal Esp32DeviceInfo GetDeviceDetails(string targetName)
         {
             string messages;
 
@@ -134,7 +134,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
 
             // execute flash_id command and parse the result
-            if (!RunEspTool("flash_id", true, false, null, out messages))
+            if (!RunEspTool("flash_id", !targetName.Equals("ESP32_PICO", StringComparison.InvariantCultureIgnoreCase), false, null, out messages))
             {
                 throw new EspToolExecutionException(messages);
             }

--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -295,7 +295,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     try
                     {
-                        esp32Device = espTool.GetDeviceDetails();
+                        esp32Device = espTool.GetDeviceDetails(o.TargetName);
                     }
                     catch (EspToolExecutionException ex)
                     {


### PR DESCRIPTION
## Description
The ESP32_PICO need to have stub flashed otherwise the flash size detection is not working and return UNKNOW

## Motivation and Context
When trying to flash an ESP32_PICO, the tool is crashing because he tries to cast "UNKNOW" in int.
There is, maybe, a problem if the user asked for an backup because we flash stub over the current content of the flash.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
I've tested it by flashing my device

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [?] All new and existing tests passed. (there is tests ? I don't see any)
