### PR TITLE
Improvements in ESP32 operations

### DIFF
--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -295,7 +295,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     try
                     {
-                        esp32Device = espTool.GetDeviceDetails();
+                        esp32Device = espTool.GetDeviceDetails(o.Esp32PartitionTableSize == null);
                     }
                     catch (EspToolExecutionException ex)
                     {
@@ -323,6 +323,24 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     Console.WriteLine($"{ esp32Device }");
 
                     Console.ForegroundColor = ConsoleColor.White;
+
+                    // if this is a PICO and baudrate is not 115200 operations will most likely fail
+                    // warn user about this
+                    if(
+                        esp32Device.ChipName.Contains("ESP32-PICO")
+                        && o.BaudRate != 115200)
+                    {
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+
+                        Console.WriteLine("");
+                        Console.WriteLine("****************************** WARNING ******************************");
+                        Console.WriteLine("The connected device it's an ESP32 PICO which can be picky about the ");
+                        Console.WriteLine("baud rate used. Recommendation is to use --baud 115200 ");
+                        Console.WriteLine("*********************************************************************");
+                        Console.WriteLine("");
+
+                        Console.ForegroundColor = ConsoleColor.White;
+                    }
                 }
 
                 // set verbosity


### PR DESCRIPTION
## Description
- Improved support for PICO devices, in particular M5 ATOM which are very picky about the baud rate.
- Add new parameter to RunEspTool: now allows to set the use of standard baud rate or not.
- Add code to perform a second attempt to read device details on failure by not using the stub and just using the standard baud rate.
- Chip type is now automatically set after getting device details.
- Warning is issued with connecting to a PICO device with a baud rate other than 115200.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
