### PR TITLE
Fix FEATHER_S2 update

### DIFF
--- a/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/nanoFirmwareFlasher/Esp32Operations.cs
@@ -290,6 +290,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 #if FEATHER_S2_DELAY
                 if (targetName.Contains("FEATHER_S2"))
                 {
+                    // by experimentation 15s seems to be the minimum for guaranteed success
                     Thread.Sleep(TimeSpan.FromSeconds(15));
                 }
 #endif
@@ -316,6 +317,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 #if FEATHER_S2_DELAY
                 if (targetName.Contains("FEATHER_S2"))
                 {
+                    // by experimentation 15s seems to be the minimum for guaranteed success
                     Thread.Sleep(TimeSpan.FromSeconds(15));
                 }
 #endif

--- a/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/nanoFirmwareFlasher/Esp32Operations.cs
@@ -3,8 +3,6 @@
 // See LICENSE file in the project root for full license information.
 //
 
-#define FEATHER_S2_DELAY
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -287,14 +285,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             if (updateFw)
             {
-#if FEATHER_S2_DELAY
-                if (targetName.Contains("FEATHER_S2"))
-                {
-                    // by experimentation 15s seems to be the minimum for guaranteed success
-                    Thread.Sleep(TimeSpan.FromSeconds(15));
-                }
-#endif
-
                 // erase flash
                 operationResult = espTool.EraseFlash();
             }
@@ -314,14 +304,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             if (operationResult == ExitCodes.OK)
             {
-#if FEATHER_S2_DELAY
-                if (targetName.Contains("FEATHER_S2"))
-                {
-                    // by experimentation 15s seems to be the minimum for guaranteed success
-                    Thread.Sleep(TimeSpan.FromSeconds(15));
-                }
-#endif
-
                 if (verbosity >= VerbosityLevel.Normal)
                 {
                     Console.ForegroundColor = ConsoleColor.Green;

--- a/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/nanoFirmwareFlasher/Esp32Operations.cs
@@ -3,10 +3,13 @@
 // See LICENSE file in the project root for full license information.
 //
 
+#define FEATHER_S2_DELAY
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
@@ -284,6 +287,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             if (updateFw)
             {
+#if FEATHER_S2_DELAY
+                if (targetName.Contains("FEATHER_S2"))
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(15));
+                }
+#endif
+
                 // erase flash
                 operationResult = espTool.EraseFlash();
             }
@@ -303,6 +313,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             if (operationResult == ExitCodes.OK)
             {
+#if FEATHER_S2_DELAY
+                if (targetName.Contains("FEATHER_S2"))
+                {
+                    Thread.Sleep(TimeSpan.FromSeconds(15));
+                }
+#endif
+
                 if (verbosity >= VerbosityLevel.Normal)
                 {
                     Console.ForegroundColor = ConsoleColor.Green;

--- a/nanoFirmwareFlasher/EspTool.cs
+++ b/nanoFirmwareFlasher/EspTool.cs
@@ -60,12 +60,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// </summary>
         private int _flashSize = -1;
 
-        /// <summary>
-        /// true if the stub program is already active and we can use the --before no_reset_no_sync parameter 
-        /// </summary>
-        private bool _isStubActive = false;
         private bool connectPatternFound;
+
         private DateTime connectTimeStamp;
+
         private bool connectPromptShown;
 
         /// <summary>
@@ -531,7 +529,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             string noStubParameter = null;
             string baudRateParameter = null;
             string beforeParameter = null;
-            string afterParameter = hardResetAfterCommand ? "hard_reset" : "no_reset";
+            string afterParameter = hardResetAfterCommand ? "hard_reset" : "no_reset_stub";
 
             if (noStub)
             {
@@ -672,9 +670,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             // save output messages
             _esptoolMessage = messages;
-
-            // if the stub program was used then we don't need to transfer ist again
-            _isStubActive = !noStub;
 
             if(espTool.ExitCode == 0)
             {

--- a/nanoFirmwareFlasher/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher/FirmwarePackage.cs
@@ -73,7 +73,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             if (verbosity >= VerbosityLevel.Normal)
             {
                 Console.ForegroundColor = ConsoleColor.White;
-                Console.Write($"Trying to find list of boards in {(preview ? "developement" : "stable")} repository");
+                Console.Write($"Trying to find list of boards in {(preview ? "development" : "stable")} repository");
                 if( string.IsNullOrEmpty(filter))
                 {
                     Console.Write(" without filter");
@@ -196,7 +196,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     if (Verbosity >= VerbosityLevel.Normal)
                     {
                         Console.ForegroundColor = ConsoleColor.White;
-                        Console.Write($"Trying to find {_targetName} in {(_preview ? "developement" : "stable")} repository...");
+                        Console.Write($"Trying to find {_targetName} in {(_preview ? "development" : "stable")} repository...");
                     }
 
                     HttpResponseMessage response = await _cloudsmithClient.GetAsync(requestUri);


### PR DESCRIPTION
## Description
- For FeatherS2 only, after querying chipID create a 15s delay.
- For FeatherS2 only, after flash erase create a 15s delay.
- minor spelling update to user interface developement -> development.

## Motivation and Context
Adafruit FeatherS2 appears not to comply with 'no_reset' command in ESP programming tool
for instance in the RunEspTool() Process call the arguments for .StartInfo are,
For ChipID check: "--port COM6  --chip auto   --after no_reset flash_id"
For flash erase "--port COM6  --chip esp32s2   --after no_reset erase_flash"
however after each operation the device appears to reset and a USB enumeration occurs. There is no existing time allowance in the code for this and subsequent operation occurs when no COM port exists resulting in 100% fail rate.

## How Has This Been Tested?
Code has been tested against Adafruit FeatherS2. It is unknown what other devices may exhibit this issue.

## Screenshots
without fix the following exception occurs,
![image](https://user-images.githubusercontent.com/9397408/140167221-fe2c0ed8-2278-47d2-aa63-cf5de64583a1.png)

## Types of changes
- [X] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
