### PR TITLE
Fix deployment operation for ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,11 @@ nanoff --target ESP32_PSRAM_REV0 --serialport COM12 --deploy --image "E:\GitHub\
 
 ### Update the firmware of an ESP32 target along with a managed application
 
-To update the firmware of an ESP32 target connected to COM31, to the latest available development version.
-You have to specify the path to the managed application.
-This example uses the binary format file that was saved on a previous backup operation.
+To deploy an application on an ESP32 target connected to COM31, with your application, you have to specify the path to the managed application and the deployment address.
+This example uses the binary format file that you can find when you are building an application. Note, as only application can run, when you are building a library, a bin file is not created automatically. Only for application.
 
 ```console
-nanoff --update --target ESP32_PSRAM_REV0 --serialport COM31 --deployment "c:\eps32-backups\my_awesome_app.bin"
+nanoff --target ESP32_PSRAM_REV0 --serialport COM31 --deploy --image "c:\eps32-backups\my_awesome_app.bin" --address 0x1B000
 ```
 
 ## STMP32 usage examples 

--- a/README.md
+++ b/README.md
@@ -138,21 +138,21 @@ nanoff --platform esp32 --serialport COM31 --devicedetails
 
 ### Deploy a managed application to an ESP32 target
 
-To deploy a managed application to an ESP32_PSRAM_REV0 target connected to COM31, which has the deployment region at 0x190000 flash address.
+To deploy a managed application to an ESP32_PSRAM_REV0 target connected to COM31.
 
 >Note: The binary file with the deployment image can be found on the Release or Debug folder of a Visual Studio project after a successful build. This file contains everything that's required to deploy a managed application to a target (meaning application executable and all referenced libraries and assemblies).
 
 ```console
-nanoff --target ESP32_PSRAM_REV0 --serialport COM12 --deploy --image "E:\GitHub\nf-Samples\samples\Blinky\Blinky\bin\Debug\Blinky.bin" --address 0x190000
+nanoff --target ESP32_PSRAM_REV0 --serialport COM12 --deploy --image "E:\GitHub\nf-Samples\samples\Blinky\Blinky\bin\Debug\Blinky.bin"
 ```
 
 ### Update the firmware of an ESP32 target along with a managed application
 
-To deploy an application on an ESP32 target connected to COM31, with your application, you have to specify the path to the managed application and the deployment address.
-This example uses the binary format file that you can find when you are building an application. Note, as only application can run, when you are building a library, a bin file is not created automatically. Only for application.
+To deploy an application on an ESP32 target connected to COM31, with your application, you have to specify the path to the managed application. Optionally you can provide an address which will override the default deployment address.
+This example uses the binary format file that you can find when you are building an application. Note, as only application can run, when you are building a library, a bin file is not created automatically. Only for applications.
 
 ```console
-nanoff --target ESP32_PSRAM_REV0 --serialport COM31 --deploy --image "c:\eps32-backups\my_awesome_app.bin" --address 0x1B000
+nanoff --target ESP32_PSRAM_REV0 --update --serialport COM31 --deploy --image "c:\eps32-backups\my_awesome_app.bin" --address 0x1B000
 ```
 
 ## STMP32 usage examples 

--- a/nanoFirmwareFlasher/Esp32Firmware.cs
+++ b/nanoFirmwareFlasher/Esp32Firmware.cs
@@ -33,9 +33,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
         internal PartitionTableSize? _partitionTableSize;
 
         /// <summary>
-        /// Address of the deployment partition.
+        /// Default address of the deployment partition.
         /// </summary>
-        internal int DeploymentPartitionAddress =>  0x110000;
+        internal int DeploymentPartitionAddress => 0x1B0000;
 
         public Esp32Firmware(
             string targetName,

--- a/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/nanoFirmwareFlasher/Esp32Operations.cs
@@ -294,8 +294,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                 // need to get deployment address here
                 // length must both be multiples of the SPI flash erase sector size. This is 0x1000 (4096) bytes for supported flash chips.
-
-                var fileStream = File.OpenRead(firmware.BootloaderPath);
+                string bootpath = firmware.BootloaderPath ?? Path.Combine("esp32bootloader", "bootloader.bin");
+                var fileStream = File.OpenRead(bootpath);
 
                 uint fileLength = (uint)Math.Ceiling((decimal)fileStream.Length / 0x1000) * 0x1000;
 

--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -449,17 +449,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 if (o.Deploy)
                 {
                     // need to take care of flash address
-                    string appFlashAddress = null;
+                    string appFlashAddress = string.Empty;
 
                     if (o.FlashAddress.Any())
                     {
                         // take the first address, it should be the only one valid
                         appFlashAddress = o.FlashAddress.ElementAt(0);
-                    }
-                    else
-                    {
-                        _exitCode = ExitCodes.E9009;
-                        return;
                     }
 
                     // this to flash a deployment image without updating the firmware

--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -464,7 +464,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                         _exitCode = await Esp32Operations.UpdateFirmwareAsync(
                             espTool,
                             esp32Device,
-                            null,
+                            o.TargetName,
                             false,
                             null,
                             false,

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.28",
+  "version": "1.29",
   "assemblyVersion": {
     "precision": "minor"
   },


### PR DESCRIPTION
## Description
- Fix default address for deployment partition.
- Deployment address is not mandatory anymore.
- Missing target name when calling UpdateFirmwareAsync for deploy operation.
- Fix code to deploy only operation.
- Bump version to 1.29.

## Motivation and Context
- Fix deployment app esp32.
- Consider that deploy address is not mandatory (we have either a default one or one from the target partition table).
- No need to flash bootloader when flashing to deployment partition (even if it's the only operation executing).
- Improve associated documentation

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On a real ESP32 with the blinky app

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
