### PR TITLE
Improve listing of available targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,15 +259,23 @@ This is convenient, for example, if this tool is being used in a automated proce
 nanoff -v q
 ```
 
-## List all supported boards
+## List targets
 
-You can list the supported boards, their versions, either for stable versions or preview.
+You can list the supported targets, their versions, either for stable versions or preview. `--platform` allows you to filter for a platform. `--preview` filters the query to show only preview versions.
+
+List packages available for ESP32 targets in preview version.
 
 ```console
-nanoff --listboards --platform ESP --preview
+nanoff --listboards --platform esp32 --preview
 ```
 
-If you just use `--listboards` options, you'll get the list of all the stable versions for all boards. `--platform` allows you to filter.
+List packages available for STM32 targets in (stable version).
+
+```console
+nanoff --listboards --platform stm32
+```
+
+If you just use `--listtargets` switch, you'll get the list of all the stable packages for all targets.
 
 ## Exit codes
 

--- a/nanoFirmwareFlasher/ExitCodes.cs
+++ b/nanoFirmwareFlasher/ExitCodes.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace nanoFramework.Tools.FirmwareFlasher
@@ -266,5 +267,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// </summary>
         [Display(Name = "CLR image file has wrong format.It has to be a binary file.")]
         E9012 = 9012,
+
+        /// <summary>
+        /// Unsupported platform.
+        /// </summary>
+        [Display(Name = "Unsupported platform. Valid options are: esp32, stm32, cc13x2")]
+        E9013 = 9013,
     }
 }

--- a/nanoFirmwareFlasher/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher/FirmwarePackage.cs
@@ -11,7 +11,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
-using System.Web;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
@@ -64,23 +63,75 @@ namespace nanoFramework.Tools.FirmwareFlasher
             _preview = preview;
         }
 
-        public static List<CloudSmithPackageDetail> GetBoardList(bool communityTargets, bool preview, string filter, VerbosityLevel verbosity)
+        /// <summary>
+        /// Get a list of all available targets from Cloudsmith repository.
+        /// </summary>
+        /// <param name="communityTargets"><see langword="true"/> to list community targets.<see langword="false"/> to list reference targets.</param>
+        /// <param name="preview">Option for preview version.</param>
+        /// <param name="platform">Platform code to use on search.</param>
+        /// <param name="verbosity">VerbosityLevel to use when outputting progress and error messages.</param>
+        /// <returns>List of <see cref="CloudSmithPackageDetail"/> with details on target firmware packages.</returns>
+        public static List<CloudSmithPackageDetail> GetTargetList(
+            bool communityTargets,
+            bool preview,
+            SupportedPlatform? platform,
+            VerbosityLevel verbosity)
         {
-            string repoName = communityTargets ? _communityTargetsRepo : preview ? _refTargetsDevRepo : _refTargetsStableRepo;
-            string requestUri = $"{_cloudsmithPackages}/{repoName}/?query={filter}";
-            List<CloudSmithPackageDetail> boardNames = new List<CloudSmithPackageDetail>();
+            string queryFilter = string.Empty;
 
-            if (verbosity >= VerbosityLevel.Normal)
+            // build query filter according to platform using package name
+            if (platform != null)
+            {
+                List<string> query = new(); 
+
+                switch(platform)
+                {
+                    case SupportedPlatform.esp32:
+                        query.Add("ESP");
+                        query.Add("M5");
+                        query.Add("Pyb");
+                        query.Add("FEATHER");
+                        query.Add("KALUGA");
+                        break;
+
+                    case SupportedPlatform.stm32:
+                        query.Add("ST");
+                        query.Add("ORGPAL");
+                        query.Add("NETDUINO3");
+                        query.Add("QUAIL");
+                        query.Add("GHI");
+                        query.Add("IngenuityMicro");
+                        query.Add("WeAct");
+                        break;
+
+                    case SupportedPlatform.cc13x2:
+                        query.Add("TI");
+                        break;
+                }
+
+                queryFilter = string.Join(" OR ", query.Select(t => $"name:{t}"));
+            }
+
+            string repoName = communityTargets ? _communityTargetsRepo : preview ? _refTargetsDevRepo : _refTargetsStableRepo;
+            string requestUri = $"{_cloudsmithPackages}/{repoName}/?query={queryFilter}";
+            List<CloudSmithPackageDetail> targetPackages = new();
+
+            if (verbosity > VerbosityLevel.Normal)
             {
                 Console.ForegroundColor = ConsoleColor.White;
-                Console.Write($"Trying to find list of boards in {(preview ? "development" : "stable")} repository");
-                if( string.IsNullOrEmpty(filter))
+
+                Console.Write($"Listing {platform} targets from '{repoName}' repository");
+
+                if (!communityTargets)
                 {
-                    Console.Write(" without filter");
-                }
-                else
-                {
-                    Console.Write($" with filter {filter}");
+                    if (preview)
+                    {
+                        Console.Write(" [PREVIEW]");
+                    }
+                    else
+                    {
+                        Console.Write(" [STABLE]");
+                    }
                 }
 
                 Console.WriteLine("...");
@@ -99,12 +150,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
 
                 // can't find this target
-                return boardNames;
+                return targetPackages;
             }
 
-            boardNames = JsonConvert.DeserializeObject<List<CloudSmithPackageDetail>>(responseBody);
+            targetPackages = JsonConvert.DeserializeObject<List<CloudSmithPackageDetail>>(responseBody);
 
-            return boardNames;
+            return targetPackages;
         }
 
         /// <summary>
@@ -223,12 +274,24 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                         if (responseBody == "[]")
                         {
+                            // can't find this target
+
+                            Console.WriteLine("");
+
                             if (Verbosity >= VerbosityLevel.Normal)
                             {
-                                Console.WriteLine("");
-                            }
+                                // output helpful message
+                                Console.ForegroundColor = ConsoleColor.Yellow;
 
-                            // can't find this target
+                                Console.WriteLine("");
+                                Console.WriteLine("*************************** ERROR **************************");
+                                Console.WriteLine("Couldn't find this target in our Cloudsmith repositories!");
+                                Console.WriteLine("To list the available targets use this option --listtargets.");
+                                Console.WriteLine("************************************************************");
+                                Console.WriteLine("");
+
+                                Console.ForegroundColor = ConsoleColor.White;
+                            }
                             return ExitCodes.E9005;
                         }
                     }

--- a/nanoFirmwareFlasher/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher/FirmwarePackage.cs
@@ -89,7 +89,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     case SupportedPlatform.esp32:
                         query.Add("ESP");
                         query.Add("M5");
-                        query.Add("Pyb");
                         query.Add("FEATHER");
                         query.Add("KALUGA");
                         break;
@@ -102,6 +101,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                         query.Add("GHI");
                         query.Add("IngenuityMicro");
                         query.Add("WeAct");
+                        query.Add("Pyb");
                         break;
 
                     case SupportedPlatform.cc13x2:

--- a/nanoFirmwareFlasher/Options.cs
+++ b/nanoFirmwareFlasher/Options.cs
@@ -177,7 +177,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             Required = false,
             Default = null,
             HelpText = "Target platform. Acceptable values are: esp32, stm32, cc13x2.")]
-        public string Platform { get; set; }
+        public SupportedPlatform? Platform { get; set; }
 
         /// <summary>
         /// Allowed values:
@@ -277,6 +277,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
             Default = false,
             HelpText = "List the available boards and versions available on CloudSmith.")]
         public bool ListBoards { get; set; }
+
+        [Option(
+            "listtargets",
+            Required = false,
+            Default = false,
+            HelpText = "List the available targets and versions. --platform and --preview options apply.")]
+        public bool ListTargets { get; set; }
+
         #endregion
 
 
@@ -289,9 +297,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 new("Update ESP32 device with custom firmware (local bin file)", new Options { TargetName = "ESP32_WROOM_32" , DeploymentImage = "<location of file>.bin"}),
                 new("Update specific STM32 device (ST_STM32F769I_DISCOVERY) with latest available firmware (preview version), using JTAG interface", new Options { TargetName = "ST_STM32F769I_DISCOVERY" , Update = true, Preview = true, JtagUpdate = true}),
                 new("Update specific STM32 device (NETDUINO3_WIFI) with latest available firmware (preview version), device is connected through DFU with Id 3380386D3134", new Options { TargetName = "NETDUINO3_WIFI",  Update = true, Preview = true, DfuDeviceId = "3380386D3134" }),
-                new("List all STM32 devices connected through JTAG", new Options { Platform = "stm32", ListJtagDevices = true}),
+                new("List all STM32 devices connected through JTAG", new Options { Platform = SupportedPlatform.esp32, ListJtagDevices = true}),
                 new("Install STM32 JTAG drivers", new Options { InstallJtagDrivers = true}),
-                new("List all boards", new Options { ListBoards = true, Preview = true, Platform = "ESP" }),
+                new("List all available targets", new Options { ListTargets = true, Preview = true, Platform =  SupportedPlatform.stm32 }),
             };
     }
 
@@ -310,5 +318,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
         _4 = 4,
         _8 = 8,
         _16 = 16,
+    }
+
+    public enum SupportedPlatform
+    {
+        esp32 = 0,
+        stm32 = 1,
+        cc13x2 = 2
     }
 }


### PR DESCRIPTION
## Description
- Platform option is now an enum.
- Add new exit code with platform validation.
- Rework code accordingly.
- Rework target listing.
- Add new option listtargets to replace listboards.
- Improve output with helpful messages.

## Motivation and Context
- Improve usability and provide helpful messages whenever possible.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
