### PR TITLE
Improve output on failure to open COM port

### DIFF
--- a/nanoFirmwareFlasher/EspTool.cs
+++ b/nanoFirmwareFlasher/EspTool.cs
@@ -103,20 +103,32 @@ namespace nanoFramework.Tools.FirmwareFlasher
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                // open/close the port to see if it is available
-                using (var test = new SerialPort(serialPort, baudRate))
-                {
+                // open/close the COM port to check if it is available
+                var test = new SerialPort(serialPort, baudRate);
 
-                    try
+                try
+                {
+                    test.Open();
+                    test.Close();
+                }
+                catch(Exception ex)
+                {
+                    if (Verbosity >= VerbosityLevel.Detailed)
                     {
-                        test.Open();
-                        test.Close();
+                        Console.ForegroundColor = ConsoleColor.DarkRed;
+                            
+                        Console.WriteLine("");
+                        Console.WriteLine("******************* EXCEPTION *****************");
+                        Console.WriteLine($"Exception occurred while trying to open <{serialPort}>:");
+                        Console.WriteLine($"{ex.Message}");
+                        Console.WriteLine("***********************************************");
+                        Console.WriteLine("");
+
+                        Console.ForegroundColor = ConsoleColor.White;
                     }
-                    catch
-                    {
-                        // presume any exception here is caused by the serial not existing or not possible to open
-                        throw new EspToolExecutionException();
-                    }
+
+                    // presume any exception here is caused by the serial not existing or not possible to open
+                    throw new EspToolExecutionException();
                 }
             }
             else


### PR DESCRIPTION
## Description
- Add output message with exception details.
- Remove using wrapping the SerialPort object.

## Motivation and Context
- Improves output to help diagnose weird occurrences of failures to use a SerialPort that's supposed to be free.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (work on Unit Tests, has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
