### PR TITLE
Replace ESP32 target names

### DIFF
--- a/nanoFirmwareFlasher/Options.cs
+++ b/nanoFirmwareFlasher/Options.cs
@@ -299,9 +299,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
         public static IEnumerable<Example> Examples =>
             new List<Example>
             {
-                new("Update ESP32 device with latest available firmware (stable version)", new Options { TargetName = "ESP32_WROOM_32", Update = true }),
-                new("Update ESP32 device with latest available firmware (stable version), device is connected to COM31", new Options { TargetName = "ESP32_WROOM_32", Update = true, SerialPort = "COM31" }),
-                new("Update ESP32 device with custom firmware (local bin file)", new Options { TargetName = "ESP32_WROOM_32" , DeploymentImage = "<location of file>.bin"}),
+                new("Update ESP32 WROVER Kit device with latest available firmware (stable version)", new Options { TargetName = "ESP_WROVER_KIT", Update = true }),
+                new("Update ESP32 device with latest available firmware (stable version), device is connected to COM31", new Options { TargetName = "ESP32_PSRAM_REV0", Update = true, SerialPort = "COM31" }),
+                new("Update ESP32 device with custom firmware (local bin file)", new Options { TargetName = "ESP_WROVER_KIT" , DeploymentImage = "<location of file>.bin"}),
                 new("Update specific STM32 device (ST_STM32F769I_DISCOVERY) with latest available firmware (preview version), using JTAG interface", new Options { TargetName = "ST_STM32F769I_DISCOVERY" , Update = true, Preview = true, JtagUpdate = true}),
                 new("Update specific STM32 device (NETDUINO3_WIFI) with latest available firmware (preview version), device is connected through DFU with Id 3380386D3134", new Options { TargetName = "NETDUINO3_WIFI",  Update = true, Preview = true, DfuDeviceId = "3380386D3134" }),
                 new("List all STM32 devices connected through JTAG", new Options { Platform = SupportedPlatform.esp32, ListJtagDevices = true}),


### PR DESCRIPTION
## Description
- Replace ESP32 target names.

## Motivation and Context
- The help text was using deprecated target names which could be misleading.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
