### PR TITLE
Improve output regarding ESP32 PSRAM availability

### DIFF
--- a/nanoFirmwareFlasher/Esp32DeviceInfo.cs
+++ b/nanoFirmwareFlasher/Esp32DeviceInfo.cs
@@ -128,8 +128,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             switch(PSRamAvailable)
             {
-                case PSRamAvailability.Unknown:
-                    deviceInfo.AppendLine($"PSRAM: unknown");
+                case PSRamAvailability.Undetermined:
+                    deviceInfo.AppendLine($"PSRAM: undetermined");
                     break;
 
                 case PSRamAvailability.Yes:

--- a/nanoFirmwareFlasher/EspTool.cs
+++ b/nanoFirmwareFlasher/EspTool.cs
@@ -239,7 +239,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             _chipType = chipType.ToLower().Replace("-", "");
 
             // try to find out if PSRAM is present
-            PSRamAvailability psramIsAvailable = PSRamAvailability.Unknown;
+            PSRamAvailability psramIsAvailable = PSRamAvailability.Undetermined;
 
             if (name.Contains("PICO"))
             {
@@ -286,7 +286,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <returns>Information about availability of PSRAM, if that was possible to determine.</returns>
         private PSRamAvailability FindPSRamAvailable()
         {
-            PSRamAvailability pSRamAvailability = PSRamAvailability.Unknown;
+            PSRamAvailability pSRamAvailability = PSRamAvailability.Undetermined;
 
             // don't want to output anything from esptool
             // backup current verbosity setting
@@ -314,7 +314,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     // this board was put on download mode manually, can't run the test app...
 
-                    return PSRamAvailability.Unknown;
+                    return PSRamAvailability.Undetermined;
                 }
 
                 try

--- a/nanoFirmwareFlasher/PSRamAvailability.cs
+++ b/nanoFirmwareFlasher/PSRamAvailability.cs
@@ -11,9 +11,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
     internal enum PSRamAvailability
     {
         /// <summary>
-        /// Availability unknown.
+        /// Availability hasn't been determined.
         /// </summary>
-        Unknown = 0,
+        Undetermined = 0,
 
         /// <summary>
         /// PSRAM is available.


### PR DESCRIPTION
## Description
- Change enum and output string.

## Motivation and Context
- The existing output "unknown" maybe misleading. Replacing with "undetermined" trying to make it clearer.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
