### PR TITLE
Add check for ESP32 devices with 26MHz crystal

### DIFF
--- a/nanoFirmwareFlasher/Esp32Operations.cs
+++ b/nanoFirmwareFlasher/Esp32Operations.cs
@@ -125,10 +125,37 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     {
                         var revisionSuffix = "REV0";
                         var psRamSegment = "";
+                        var otherSegment = "";
 
                         if (esp32Device.ChipName.Contains("revision 3"))
                         {
                             revisionSuffix = "REV3";
+                        }
+
+                        if (esp32Device.Crystal.StartsWith("26"))
+                        {
+                            // this one requires the 26MHz version
+                            // and we only have a PSRAM version for this
+
+                            // check that 
+                            if (esp32Device.PSRamAvailable != PSRamAvailability.Yes)
+                            {
+                                Console.ForegroundColor = ConsoleColor.Red;
+
+                                Console.WriteLine("");
+                                Console.WriteLine("The connected ESP32 device has a 26MHz crystal and no PSRAM.");
+                                Console.WriteLine("We currently don't have a firmware image for that combination. Please report this to the project team.");
+                                Console.WriteLine("");
+
+                                Console.ForegroundColor = ConsoleColor.White;
+
+                                return ExitCodes.E9000;
+                            }
+
+                            // OK to force rev0 even if that's higher
+                            revisionSuffix = "REV0";
+
+                            otherSegment = "_XTAL26";
                         }
 
                         if (esp32Device.PSRamAvailable == PSRamAvailability.Yes)
@@ -137,7 +164,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                         }
 
                         // compose target name
-                        targetName = $"ESP32{psRamSegment}_{revisionSuffix}";
+                        targetName = $"ESP32{psRamSegment}{otherSegment}_{revisionSuffix}";
                     }
                 }
                 else if (esp32Device.ChipType == "ESP32-S2")


### PR DESCRIPTION
## Description
- Add extra processing when no target name is provided to deal with ESP32 devices that have 26MHz crystal fitted.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
