### PR TITLE
Fix handling of fw version

### DIFF
--- a/nanoFirmwareFlasher/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher/FirmwarePackage.cs
@@ -28,7 +28,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         private const string _communityTargetsRepo = "nanoframework-images-community-targets";
 
         private readonly string _targetName;
-        private string _fwVersion;
         private readonly bool _preview;
 
         private const string _readmeContent = "This folder contains nanoFramework firmware files. Can safely be removed.";
@@ -76,7 +75,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             bool preview)
         {
             _targetName = targetName;
-            _fwVersion = fwVersion;
+            Version = fwVersion;
             _preview = preview;
         }
 
@@ -214,7 +213,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 // try to get download URL
                 DownloadUrlResult downloadResult = await GetDownloadUrlAsync(
                     _targetName,
-                    _fwVersion,
+                    Version,
                     _preview,
                     Verbosity);
 
@@ -224,6 +223,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
 
                 downloadUrl = downloadResult.Url;
+                
+                // update with version from package about to be downloaded
                 Version = downloadResult.Version;
 
                 stepSuccessful = !string.IsNullOrEmpty(downloadUrl);
@@ -247,7 +248,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 // reset flag
                 stepSuccessful = false;
 
-                fwFileName = $"{_targetName}-{_fwVersion}.zip";
+                fwFileName = $"{_targetName}-{Version}.zip";
 
                 // check if we already have the file
                 if (!File.Exists(
@@ -308,13 +309,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                 if (fwFiles.Any())
                 {
-                    if (string.IsNullOrEmpty(_fwVersion))
+                    if (string.IsNullOrEmpty(Version))
                     {// take the 1st one
                         fwFileName = fwFiles.First().FullName;
                     }
                     else
                     {
-                        string targetFileName = $"{_targetName}-{_fwVersion}.zip";
+                        string targetFileName = $"{_targetName}-{Version}.zip";
                         fwFileName = fwFiles.Where(w => w.Name == targetFileName).Select(s => s.FullName).FirstOrDefault();
                     }
 


### PR DESCRIPTION
## Description
- Now using class property and not backing field which messing up operations.

## Motivation and Context
- Output of fw package file and cache were messed up because of this.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
