### PR TITLE
Improve help message

### DIFF
--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -66,14 +66,16 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     new HeadingInfo(_headerInfo),
                     _copyrightInfo)
                         .AddPreOptionsLine("")
-                        .AddPreOptionsLine("ERROR: No command was provided.")
                         .AddPreOptionsLine("")
-                        .AddPreOptionsLine("Follow some examples on how to use nanoff. For more detailed explanations please check:")
+                        .AddPreOptionsLine("INFO: No command was provided.")
+                        .AddPreOptionsLine("")
+                        .AddPreOptionsLine("For the full list of commands and options use --help.")
+                        .AddPreOptionsLine("")
+                        .AddPreOptionsLine("Follows some examples on how to use nanoff. For more detailed explanations please check:")
                         .AddPreOptionsLine("https://github.com/nanoframework/nanoFirmwareFlasher#usage")
                         .AddPreOptionsLine("")
                         .AddPreOptionsLine(HelpText.RenderUsageText(result))
-                        .AddPreOptionsLine("")
-                        .AddOptions(result);
+                        .AddPreOptionsLine("");
 
                 Console.WriteLine(helpText.ToString());
 


### PR DESCRIPTION
## Description
- Now, on call without options, it shows:
  +  information message about the fact
  + instruction to use --help for a list of commands and options.
  + doesn't list the commands anymore as the list is extensive and potentially hides the relevant information that's at the top

## Motivation and Context
- Hopefully improves the visibility of the information and help message when no command was provided.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
