### PR TITLE
Add option to set Silabs JLink VCP baud rate

### DIFF
--- a/nanoFirmwareFlasher/Options.cs
+++ b/nanoFirmwareFlasher/Options.cs
@@ -179,6 +179,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
             HelpText = "ID of the J-Link device to update. If not specified the first connected J-Link device will be used.")]
         public string JLinkDeviceId { get; set; }
 
+        [Option(
+            "setvcpbr",
+            Required = false,
+            HelpText = "Set baud rate of J-Link Virtual COM Port. If a value is not specified it will use the default value for Wire Protocol.")]
+        public int? SetVcpBaudRate { get; set; }
+
         #endregion
 
 

--- a/nanoFirmwareFlasher/Program.cs
+++ b/nanoFirmwareFlasher/Program.cs
@@ -1148,8 +1148,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
                             Console.WriteLine($"Connected to J-Link device with ID {jlinkDevice.ProbeId}");
                         }
 
-                        // set VCP baud rate (if needed)
-                        _ = SilinkCli.SetVcpBaudRate(o.JLinkDeviceId is null ? connectedJLinkDevices.First() : "", _verbosityLevel);
+                        // set VCP baud rate (if requested)
+                        if (o.SetVcpBaudRate.HasValue)
+                        {
+                            _ = SilinkCli.SetVcpBaudRate(
+                                o.JLinkDeviceId is null ? connectedJLinkDevices.First() : "",
+                                o.SetVcpBaudRate.Value,
+                                _verbosityLevel);
+                        }
 
                         // set verbosity
                         jlinkDevice.Verbosity = _verbosityLevel;
@@ -1200,8 +1206,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                         operationPerformed = true;
 
-                        // set VCP baud rate (if needed)
-                        _ = SilinkCli.SetVcpBaudRate(o.JLinkDeviceId is null ? connectedJLinkDevices.First() : "", _verbosityLevel);
+                        if (o.SetVcpBaudRate.HasValue)
+                        {
+                            // set VCP baud rate (if needed)
+                            _ = SilinkCli.SetVcpBaudRate(
+                                o.JLinkDeviceId is null ? connectedJLinkDevices.First() : "",
+                                o.SetVcpBaudRate.Value,
+                                _verbosityLevel);
+                        }
 
                         if (_exitCode != ExitCodes.OK)
                         {


### PR DESCRIPTION
## Description
- Add option to set VCP baud rate.
- Rework silink class to handle this new option.

## Motivation and Context


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
