### PR TITLE
Add more documentation to library

### DIFF
--- a/nanoFirmwareFlasher.Library/CC13x26x2Operations.cs
+++ b/nanoFirmwareFlasher.Library/CC13x26x2Operations.cs
@@ -11,8 +11,22 @@ using System.Linq;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
+    /// <summary>
+    /// Class with operations available in CC13x26x2 devices.
+    /// </summary>
     public class CC13x26x2Operations
     {
+        /// <summary>
+        /// Perform firmware update on a CC13x26x2 device.
+        /// </summary>
+        /// <param name="targetName">Name of the target to update.</param>
+        /// <param name="fwVersion">Firmware version to update to.</param>
+        /// <param name="preview">Set to <see langword="true"/> to use preview version to update.</param>
+        /// <param name="updateFw">Set to <see langword="true"/> to force download of firmware package.</param>
+        /// <param name="applicationPath">Path to application to update along with the firmware update.</param>
+        /// <param name="deploymentAddress">Flash address to use when deploying an aplication.</param>
+        /// <param name="verbosity">Set verbosity level of progress and error messages.</param>
+        /// <returns>The <see cref="ExitCodes"/> with the operation result.</returns>
         public static async System.Threading.Tasks.Task<ExitCodes> UpdateFirmwareAsync(
             string targetName,
             string fwVersion,
@@ -125,6 +139,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
             return programResult;
         }
 
+        /// <summary>
+        /// Perform instalation of XDS110 drivers.
+        /// </summary>
+        /// <param name="verbosityLevel">Set verbosity level of progress and error messages.</param>
+        /// <returns>The <see cref="ExitCodes"/> with the operation result.</returns>
+        /// <exception cref="UniflashCliExecutionException">Error occurred when executing an operation with Uniflash Client.</exception>
         public static ExitCodes InstallXds110Drivers(VerbosityLevel verbosityLevel)
         {
             try

--- a/nanoFirmwareFlasher.Library/CloudSmithPackageDetails.cs
+++ b/nanoFirmwareFlasher.Library/CloudSmithPackageDetails.cs
@@ -6,9 +6,19 @@ using System.Threading.Tasks;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
+    /// <summary>
+    /// Class with details of a CloudSmith package.
+    /// </summary>
     public class CloudSmithPackageDetail
     {
+        /// <summary>
+        /// Package name.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Package version.
+        /// </summary>
         public string Version { get; set; }
     }
 }

--- a/nanoFirmwareFlasher.Library/Esp32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Operations.cs
@@ -9,8 +9,20 @@ using System.IO;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
+    /// <summary>
+    /// Class with operations available in ESP32 devices.
+    /// </summary>
     public class Esp32Operations
     {
+        /// <summary>
+        /// Perform backup of current flash content of ESP32 device.
+        /// </summary>
+        /// <param name="tool"><see cref="EspTool"/> to use when performing update.</param>
+        /// <param name="device"><see cref="Esp32DeviceInfo"/> of device to update.</param>
+        /// <param name="backupPath">Path to store backup image.</param>
+        /// <param name="fileName">Name of backup file.</param>
+        /// <param name="verbosity">Set verbosity level of progress and error messages.</param>
+        /// <returns>The <see cref="ExitCodes"/> with the operation result.</returns>
         public static ExitCodes BackupFlash(
             EspTool tool,
             Esp32DeviceInfo device,
@@ -78,6 +90,22 @@ namespace nanoFramework.Tools.FirmwareFlasher
             return ExitCodes.OK;
         }
 
+        /// <summary>
+        /// Perform firmware update on a ESP32 device.
+        /// </summary>
+        /// <param name="tool"><see cref="EspTool"/> to use when performing update.</param>
+        /// <param name="device"><see cref="Esp32DeviceInfo"/> of device to update.</param>
+        /// <param name="targetName">Name of the target to update.</param>
+        /// <param name="updateFw">Set to <see langword="true"/> to force download of firmware package.</param>
+        /// <param name="fwVersion">Firmware version to update to.</param>
+        /// <param name="preview">Set to <see langword="true"/> to use preview version to update.</param>
+        /// <param name="applicationPath">Path to application to update along with the firmware update.</param>
+        /// <param name="deploymentAddress">Flash address to use when deploying an aplication.</param>
+        /// <param name="clrFile">Path to CLR file to use for firmware update.</param>
+        /// <param name="fitCheck"><see langword="true"/> to perform validation of update package against connected target.</param>
+        /// <param name="verbosity">Set verbosity level of progress and error messages.</param>
+        /// <param name="partitionTableSize">Size of partition table.</param>
+        /// <returns>The <see cref="ExitCodes"/> with the operation result.</returns>
         public static async System.Threading.Tasks.Task<ExitCodes> UpdateFirmwareAsync(
             EspTool espTool,
             Esp32DeviceInfo esp32Device,

--- a/nanoFirmwareFlasher.Library/JLinkCli.cs
+++ b/nanoFirmwareFlasher.Library/JLinkCli.cs
@@ -14,6 +14,9 @@ using System.Threading;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
+    /// <summary>
+    /// Class that performs the interface with the JLink CLI.
+    /// </summary>
     public class JLinkCli
     {
         /// <summary>

--- a/nanoFirmwareFlasher.Library/JLinkDevice.cs
+++ b/nanoFirmwareFlasher.Library/JLinkDevice.cs
@@ -11,6 +11,9 @@ using System.Text.RegularExpressions;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
+    /// <summary>
+    /// Class representing a connected J-Link device.
+    /// </summary>
     public class JLinkDevice : JLinkCli
     {
         /// <summary>

--- a/nanoFirmwareFlasher.Library/JLinkOperations.cs
+++ b/nanoFirmwareFlasher.Library/JLinkOperations.cs
@@ -10,8 +10,24 @@ using System.Linq;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
+    /// <summary>
+    /// Class with operations available in J-Link connected devices.
+    /// </summary>
     public class JLinkOperations
     {
+        /// <summary>
+        /// Perform firmware update on a J-Link connected device.
+        /// </summary>
+        /// <param name="targetName">Name of the target to update.</param>
+        /// <param name="fwVersion">Firmware version to update to.</param>
+        /// <param name="preview">Set to <see langword="true"/> to use preview version to update.</param>
+        /// <param name="updateFw">Set to <see langword="true"/> to force download of firmware package.</param>
+        /// <param name="applicationPath">Path to application to update along with the firmware update.</param>
+        /// <param name="deploymentAddress">Flash address to use when deploying an aplication.</param>
+        /// <param name="probeId">ID of the J-Link probe to connect to.</param>
+        /// <param name="fitCheck"><see langword="true"/> to perform validation of update package against connected target.</param>
+        /// <param name="verbosity">Set verbosity level of progress and error messages.</param>
+        /// <returns>The <see cref="ExitCodes"/> with the operation result.</returns>
         public static async System.Threading.Tasks.Task<ExitCodes> UpdateFirmwareAsync(
             string targetName,
             string fwVersion,

--- a/nanoFirmwareFlasher.Library/nanoFirmwareFlasher.Library.csproj
+++ b/nanoFirmwareFlasher.Library/nanoFirmwareFlasher.Library.csproj
@@ -26,6 +26,7 @@
     <PackageIcon>images\nf-logo.png</PackageIcon>
     <PackageTags>nanoFramework, nano Framework, NETNF, NETMF, Micro Framework, .net</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description
- Enable generation of XML doc for Intellisense.

## Motivation and Context
- Add missing documentation.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
