### PR TITLE
Potential fix for executable path

### DIFF
--- a/nanoFirmwareFlasher.Library/Utilities.cs
+++ b/nanoFirmwareFlasher.Library/Utilities.cs
@@ -4,7 +4,6 @@
 //
 
 using System.IO;
-using System.Reflection;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {

--- a/nanoFirmwareFlasher.Library/Utilities.cs
+++ b/nanoFirmwareFlasher.Library/Utilities.cs
@@ -15,7 +15,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         static Utilities()
         {
             // need this to be able to use ProcessStart at the location where the .NET Core CLI tool is running from
-            string codeBase = Assembly.GetExecutingAssembly().Location;
+            string codeBase = System.AppContext.BaseDirectory;
             var fullPath = Path.GetFullPath(codeBase);
             ExecutingPath = Path.GetDirectoryName(fullPath);
         }

--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -47,7 +47,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             _copyrightInfo = new CopyrightInfo(true, $".NET Foundation and nanoFramework project contributors", 2019);
 
             // need this to be able to use ProcessStart at the location where the .NET Core CLI tool is running from
-            string codeBase = Assembly.GetExecutingAssembly().Location;
+            string codeBase = System.AppContext.BaseDirectory;
             var fullPath = Path.GetFullPath(codeBase);
             ExecutingPath = Path.GetDirectoryName(fullPath);
 


### PR DESCRIPTION
## Description
* When adding the abliity to bulid multiple frameworks within VS2022, it was quite addiment that using reflection was wrong.

## Motivation and Context
* Work on issues with multiple .Net framework versions,

## How Has This Been Tested?
* Needs a check / test to verify that this is better.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
