### PR TITLE
Improve output of J-Link probe details

### DIFF
--- a/nanoFirmwareFlasher.Library/JLinkDevice.cs
+++ b/nanoFirmwareFlasher.Library/JLinkDevice.cs
@@ -37,6 +37,16 @@ namespace nanoFramework.Tools.FirmwareFlasher
         public string DeviceCPU { get; }
 
         /// <summary>
+        /// Firmware details of the connected J-Link probe.
+        /// </summary>
+        public string Firmare { get; } = "N.A.";
+
+        /// <summary>
+        /// Hardware details of the connected J-Link probe.
+        /// </summary>
+        public string Hardware { get; } = "N.A.";
+
+        /// <summary>
         /// Creates a new <see cref="JLinkDevice"/>.
         /// </summary>
         /// <remarks>
@@ -79,12 +89,24 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
 
             // parse the output to fill in the details
-            var match = Regex.Match(cliOutput, $"(Device \")(?<deviceid>\\w*)(\" selected.)");
+            var match = Regex.Match(cliOutput, @"(Device "")(?<deviceid>\w*)("" selected\.)|(Firmware: )(?<firmware>.*)", RegexOptions.Multiline);
             if (match.Success)
             {
                 // grab details
                 DeviceId = match.Groups["deviceid"].ToString().Trim();
+
+                if (match.Groups["firmware"] != null)
+                {
+                    Firmare = match.Groups["firmware"].ToString().Trim();
+                }
             }
+
+            match = Regex.Match(cliOutput, @"(Hardware version: )(?<hardware>.*)", RegexOptions.Multiline);
+            if (match.Success && match.Groups["hardware"] != null)
+            {
+                Hardware = match.Groups["hardware"].ToString().Trim();
+            }
+
             match = Regex.Match(cliOutput, $"(Found )(?<devicecpu>.*)(,)");
             if (match.Success)
             {

--- a/nanoFirmwareFlasher.Library/JLinkOperations.cs
+++ b/nanoFirmwareFlasher.Library/JLinkOperations.cs
@@ -130,6 +130,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 Console.ForegroundColor = ConsoleColor.White;
             }
 
+            if (verbosity == VerbosityLevel.Diagnostic)
+            {
+                Console.WriteLine($"Firmware: {jlinkDevice.Firmare}");
+                Console.WriteLine($"Hardware: {jlinkDevice.Hardware}");
+            }
+
             if (fitCheck)
             {
                 Console.ForegroundColor = ConsoleColor.Yellow;
@@ -173,6 +179,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
             if (verbosity >= VerbosityLevel.Normal)
             {
                 Console.WriteLine($"Connected to J-Link device with ID {jlinkDevice.ProbeId}");
+            }
+
+            if (verbosity == VerbosityLevel.Diagnostic)
+            {
+                Console.WriteLine($"Firmware: {jlinkDevice.Firmare}");
+                Console.WriteLine($"Hardware: {jlinkDevice.Hardware}");
             }
 
             // set verbosity

--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -1295,6 +1295,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
                             Console.WriteLine($"Connected to J-Link device with ID {jlinkDevice.ProbeId}");
                         }
 
+                        if (_verbosityLevel == VerbosityLevel.Diagnostic)
+                        {
+                            Console.WriteLine($"Firmware: {jlinkDevice.Firmare}");
+                            Console.WriteLine($"Hardware: {jlinkDevice.Hardware}");
+                        }
+
                         // set VCP baud rate (if requested)
                         if (o.SetVcpBaudRate.HasValue)
                         {


### PR DESCRIPTION
## Description
- Grab hardware and firmware details of connected J-Link probe.
- Output those on verbosity diagnostic.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
