### PR TITLE
Fix usage of relative paths

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Operations.cs
@@ -303,6 +303,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     return ExitCodes.E9012;
                 }
 
+                // make sure path is absolute
+                clrFile = Utilities.MakePathAbsolute(
+                    Environment.CurrentDirectory,
+                    clrFile);
+
                 firmware.Verbosity = VerbosityLevel.Quiet;
             }
 

--- a/nanoFirmwareFlasher.Library/JLinkCli.cs
+++ b/nanoFirmwareFlasher.Library/JLinkCli.cs
@@ -228,14 +228,19 @@ Exit
             int index = 0;
             foreach (string binFile in files)
             {
+                // make sure path is absolute
+                var binFilePath = Utilities.MakePathAbsolute(
+                    Environment.CurrentDirectory,
+                    binFile);
+
                 if (Verbosity > VerbosityLevel.Normal)
                 {
                     Console.ForegroundColor = ConsoleColor.Cyan;
-                    Console.WriteLine($"{Path.GetFileName(binFile)} @ {addresses.ElementAt(index)}");
+                    Console.WriteLine($"{Path.GetFileName(binFilePath)} @ {addresses.ElementAt(index)}");
                 }
 
                 // compose JLink command file
-                var jlinkCmdContent = FlashFileCommandTemplate.Replace(FilePathToken, binFile).Replace(FlashAddressToken, addresses.ElementAt(index++));
+                var jlinkCmdContent = FlashFileCommandTemplate.Replace(FilePathToken, binFilePath).Replace(FlashAddressToken, addresses.ElementAt(index++));
                 var jlinkCmdFilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.jlink");
 
                 // create file

--- a/nanoFirmwareFlasher.Library/StmDeviceBase.cs
+++ b/nanoFirmwareFlasher.Library/StmDeviceBase.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -235,13 +236,18 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // program HEX file(s)
             foreach (string hexFile in files)
             {
+                // make sure path is absolute
+                var hexFilePath = Utilities.MakePathAbsolute(
+                    Environment.CurrentDirectory,
+                    hexFile);
+
                 if (Verbosity >= VerbosityLevel.Detailed)
                 {
                     Console.ForegroundColor = ConsoleColor.Yellow;
                     Console.WriteLine($"{Path.GetFileName(hexFile)}");
                 }
 
-                var cliOutput = RunSTM32ProgrammerCLI($"-c {connectDetails} -w \"{hexFile}\"");
+                var cliOutput = RunSTM32ProgrammerCLI($"-c {connectDetails} -w \"{hexFilePath}\"");
 
                 if (!cliOutput.Contains("File download complete"))
                 {
@@ -336,13 +342,18 @@ namespace nanoFramework.Tools.FirmwareFlasher
             int index = 0;
             foreach (string binFile in files)
             {
+                // make sure path is absolute
+                var binFilePath = Utilities.MakePathAbsolute(
+                    Environment.CurrentDirectory,
+                    binFile);
+
                 if (Verbosity >= VerbosityLevel.Detailed)
                 {
                     Console.ForegroundColor = ConsoleColor.Cyan;
-                    Console.WriteLine($"{Path.GetFileName(binFile)} @ {addresses.ElementAt(index)}");
+                    Console.WriteLine($"{Path.GetFileName(binFilePath)} @ {addresses.ElementAt(index)}");
                 }
 
-                var cliOutput = RunSTM32ProgrammerCLI($"-c {connectDetails} mode=UR -w \"{binFile}\" {addresses.ElementAt(index++)}");
+                var cliOutput = RunSTM32ProgrammerCLI($"-c {connectDetails} mode=UR -w \"{binFilePath}\" {addresses.ElementAt(index++)}");
 
                 if (!cliOutput.Contains("Programming Complete."))
                 {

--- a/nanoFirmwareFlasher.Library/Utilities.cs
+++ b/nanoFirmwareFlasher.Library/Utilities.cs
@@ -5,6 +5,7 @@
 
 using System.IO;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
@@ -19,5 +20,29 @@ namespace nanoFramework.Tools.FirmwareFlasher
             var fullPath = Path.GetFullPath(codeBase);
             ExecutingPath = Path.GetDirectoryName(fullPath);
         }
+
+
+        /// <summary>
+        /// Takes a pathname that MAY be relative and makes it absolute. If the path is already absolute, it is left alone.
+        /// </summary>
+        public static string MakePathAbsolute(
+            string baseFolder,
+            string possiblyRelativePathname)
+        {
+            // Should work on UN*X or Windows
+            string path;
+
+            if (Regex.IsMatch(possiblyRelativePathname, @"^(/|[a-zA-Z]:)"))
+            {
+                path = possiblyRelativePathname;
+            }
+            else
+            {
+                path = Path.Combine(baseFolder, possiblyRelativePathname);
+            }
+
+            return path.Replace(@"\.\", @"\");
+        }
+
     }
 }


### PR DESCRIPTION
## Description
- Add code to make sure path to working bin and hex files is absolute before passing it to the various CLI.

MakePathAbsolute code kindly provided by @sky9mike.

## Motivation and Context
- Usage of relative paths for working files was causing issues with some CLI.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
