### PR TITLE
Improve output details for JLink devices

### DIFF
--- a/nanoFirmwareFlasher.Library/JLinkDevice.cs
+++ b/nanoFirmwareFlasher.Library/JLinkDevice.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace nanoFramework.Tools.FirmwareFlasher
@@ -89,20 +90,24 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
 
             // parse the output to fill in the details
-            var match = Regex.Match(cliOutput, @"(Device "")(?<deviceid>\w*)("" selected\.)|(Firmware: )(?<firmware>.*)", RegexOptions.Multiline);
+            var match = Regex.Match(cliOutput, "(Firmware: )(?<firmware>.*)$", RegexOptions.Multiline);
             if (match.Success)
             {
-                // grab details
-                DeviceId = match.Groups["deviceid"].ToString().Trim();
-
-                if (match.Groups["firmware"] != null)
+                if (match.Groups["firmware"].Captures.Count > 0)
                 {
                     Firmare = match.Groups["firmware"].ToString().Trim();
                 }
             }
 
+            match = Regex.Match(cliOutput, @"(Device "")(?<deviceid>.*)("" selected.)", RegexOptions.Multiline);
+            if (match.Success)
+            {
+                // grab details
+                DeviceId = match.Groups["deviceid"].ToString().Trim();
+            }
+
             match = Regex.Match(cliOutput, @"(Hardware version: )(?<hardware>.*)", RegexOptions.Multiline);
-            if (match.Success && match.Groups["hardware"] != null)
+            if (match.Success && match.Groups["hardware"].Captures.Count > 0)
             {
                 Hardware = match.Groups["hardware"].ToString().Trim();
             }
@@ -174,6 +179,19 @@ namespace nanoFramework.Tools.FirmwareFlasher
             return ExecuteFlashHexFiles(
                 files,
                 ProbeId);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            StringBuilder deviceInfo = new();
+
+            deviceInfo.AppendLine($"JLink firmware: {Firmare}");
+            deviceInfo.AppendLine($"JLink hardware: {Hardware}");
+            deviceInfo.AppendLine($"CPU: {DeviceCPU}");
+            deviceInfo.AppendLine($"Device ID: {DeviceId}");
+
+            return deviceInfo.ToString();
         }
     }
 }


### PR DESCRIPTION
## Description
- Fix regexe parsing JLink output.
- Implement `ToString()` override to properly output JLink device details.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
