### PR TITLE
Remove listboards option

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,16 +413,16 @@ You can list the supported targets, and their version using the `--platform` par
 List packages available for ESP32 targets:
 
 ```console
-nanoff --listboards --platform esp32
+nanoff --listtargets --platform esp32
 ```
 
 List packages available for STM32 targets:
 
 ```console
-nanoff --listboards --platform stm32
+nanoff --listtargets --platform stm32
 ```
 
-If you use the `--listtargets` switch in conjunction with `--preview`, you'll get the list of packages that maybe used for experimental or major feature changes.
+If you use the `--listtargets` switch in conjunction with `--preview`, you'll get the list of available firmware packages that are available with experimental or major feature changes.
 
 ## Clear cache location
 

--- a/nanoFirmwareFlasher.Tool/Options.cs
+++ b/nanoFirmwareFlasher.Tool/Options.cs
@@ -300,13 +300,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         public bool FitCheck { get; set; }
 
         [Option(
-            "listboards",
-            Required = false,
-            Default = false,
-            HelpText = "List the available boards and versions available on CloudSmith.")]
-        public bool ListBoards { get; set; }
-
-        [Option(
             "listtargets",
             Required = false,
             Default = false,

--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -260,27 +260,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             #region list targets
 
-            // First check if we are asked for the list of boards
-            if (o.ListTargets ||
-                o.ListBoards)
+            // First check if we are asked for the list of available targets
+            if (o.ListTargets)
             {
-                if (o.ListBoards && _verbosityLevel > VerbosityLevel.Quiet)
-                {
-                    // warn about deprecated option
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-
-                    Console.WriteLine("");
-                    Console.WriteLine("");
-                    Console.WriteLine("********************************** WARNING **********************************");
-                    Console.WriteLine("The --listboards option is deprecated and will be removed in a future version");
-                    Console.WriteLine("Please use --listtargets option instead");
-                    Console.WriteLine("*****************************************************************************");
-                    Console.WriteLine("");
-                    Console.WriteLine("");
-
-                    Console.ForegroundColor = ConsoleColor.White;
-                }
-
                 // get list from REFERENCE targets
                 var targets = FirmwarePackage.GetTargetList(
                     false,


### PR DESCRIPTION
## Description
- Remove listboards option.
- Update code accordingly.

## Motivation and Context
- Announced as deprecated for quite some time.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
