### PR TITLE
Improve output with progress messages

### DIFF
--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -116,7 +116,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
                 catch (Exception ex)
                 {
-                    if (Verbosity >= VerbosityLevel.Detailed)
+                    if (Verbosity >= VerbosityLevel.Normal)
                     {
                         Console.ForegroundColor = ConsoleColor.DarkRed;
 

--- a/nanoFirmwareFlasher.Library/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher.Library/FirmwarePackage.cs
@@ -177,7 +177,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // check for empty array 
             if (responseBody == "[]")
             {
-                if (verbosity >= VerbosityLevel.Normal)
+                if (verbosity > VerbosityLevel.Quiet)
                 {
                     Console.WriteLine("");
                 }
@@ -378,7 +378,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     // set property
                     Version = match[0].Value;
 
-                    if (Verbosity >= VerbosityLevel.Normal)
+                    if (Verbosity > VerbosityLevel.Detailed)
                     {
                         Console.ForegroundColor = ConsoleColor.Yellow;
                         Console.WriteLine("Using cached firmware package");
@@ -389,7 +389,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     // no fw file available
 
-                    if (Verbosity >= VerbosityLevel.Normal)
+                    if (Verbosity > VerbosityLevel.Quiet)
                     {
                         Console.ForegroundColor = ConsoleColor.Red;
                         Console.WriteLine("Failure to download package and couldn't find one in the cache.");
@@ -403,7 +403,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // got here, must have a file!
 
             // unzip the firmware
-            if (Verbosity >= VerbosityLevel.Detailed)
+            if (Verbosity >= VerbosityLevel.Normal)
             {
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.Write($"Extracting {Path.GetFileName(fwFileName)}...");
@@ -413,7 +413,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 Path.Combine(LocationPath, fwFileName),
                 LocationPath);
 
-            if (Verbosity >= VerbosityLevel.Detailed)
+            if (Verbosity >= VerbosityLevel.Normal)
             {
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.WriteLine("OK");
@@ -460,7 +460,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             try
             {
-                if (verbosity >= VerbosityLevel.Normal)
+                if (verbosity >= VerbosityLevel.Detailed)
                 {
                     Console.ForegroundColor = ConsoleColor.White;
                     Console.Write($"Trying to find {targetName} in {(isPreview ? "development" : "stable")} repository...");
@@ -478,7 +478,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 // check for empty array 
                 if (responseBody == "[]")
                 {
-                    if (verbosity >= VerbosityLevel.Normal)
+                    if (verbosity >= VerbosityLevel.Detailed)
                     {
                         Console.ForegroundColor = ConsoleColor.Yellow;
                         Console.WriteLine("Not found");
@@ -488,7 +488,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     //  try now with community targets
                     repoName = _communityTargetsRepo;
 
-                    if (verbosity >= VerbosityLevel.Normal)
+                    if (verbosity >= VerbosityLevel.Detailed)
                     {
                         Console.ForegroundColor = ConsoleColor.White;
                         Console.Write($"Trying to find {targetName} in community targets repository...");
@@ -513,7 +513,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     {
                         Console.WriteLine("");
 
-                        if (verbosity >= VerbosityLevel.Normal)
+                        if (verbosity > VerbosityLevel.Quiet)
                         {
                             Console.ForegroundColor = ConsoleColor.Red;
 
@@ -553,7 +553,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                             Console.WriteLine("");
 
-                            if (verbosity >= VerbosityLevel.Normal)
+                            if (verbosity > VerbosityLevel.Quiet)
                             {
                                 Console.ForegroundColor = ConsoleColor.Red;
 
@@ -581,7 +581,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                     Console.WriteLine("");
 
-                    if (verbosity >= VerbosityLevel.Normal)
+                    if (verbosity > VerbosityLevel.Quiet)
                     {
                         // output helpful message
                         Console.ForegroundColor = ConsoleColor.Red;
@@ -599,7 +599,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     return new DownloadUrlResult(string.Empty, string.Empty, ExitCodes.E9005);
                 }
 
-                if (verbosity >= VerbosityLevel.Normal)
+                if (verbosity > VerbosityLevel.Quiet)
                 {
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.WriteLine($"OK");


### PR DESCRIPTION
## Description
- Rework conditions showing (or not) progress and feedback output.

## Motivation and Context
- After #219 there were some inconsistencies in the verbosity for regular operations. Also some complains that the default feedback should be more verbose. These changes try to address all this and strike a balance between reasonable (and consistent) output verbosity.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
