### PR TITLE
Remove flash options for esptool

### DIFF
--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -34,23 +34,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         private int _baudRate = 0;
 
         /// <summary>
-        /// The flash mode for the esptool.
-        /// </summary>
-        /// <remarks>
-        /// See https://github.com/espressif/esptool#flash-modes for more details
-        /// </remarks>
-        private readonly string _flashMode = null;
-
-        /// <summary>
-        /// The flash frequency for the esptool.
-        /// </summary>
-        /// <remarks>
-        /// This value should be in Hz; 40 MHz = 40.000.000 Hz
-        /// See https://github.com/espressif/esptool#flash-modes for more details
-        /// </remarks>
-        private readonly int _flashFrequency = 0;
-
-        /// <summary>
         /// Partition table size, when specified in the options.
         /// </summary>
         private readonly PartitionTableSize? _partitionTableSize = null;
@@ -150,8 +133,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // set properties
             _serialPort = serialPort;
             _baudRate = baudRate;
-            _flashMode = flashMode;
-            _flashFrequency = flashFrequency;
             _partitionTableSize = partitionTableSize;
         }
 
@@ -496,7 +477,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             // execute write_flash command and parse the result; progress message can be found be searching for linefeed
             if (!RunEspTool(
-                $"write_flash --flash_mode {_flashMode} --flash_freq {_flashFrequency}m --flash_size {flashSize} {partsArguments.ToString().Trim()}",
+                $"write_flash --flash_size {flashSize} {partsArguments.ToString().Trim()}",
                 false,
                 useStandardBaudrate,
                 true,


### PR DESCRIPTION
## Description
- Remove flash size and frequency options.

## Motivation and Context
- These were mandatory in early versions of esptool. Right now they are only required for advanced usage, which we don't have use for.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
