### PR TITLE
More improvements in progress output

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Operations.cs
@@ -399,7 +399,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 if (verbosity >= VerbosityLevel.Normal)
                 {
                     Console.ForegroundColor = ConsoleColor.White;
-                    Console.WriteLine($"Erasing flash...");
+                    Console.Write($"Erasing flash...");
                 }
 
                 // erase flash
@@ -425,7 +425,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                 if (verbosity >= VerbosityLevel.Normal)
                 {
-                    Console.WriteLine($"Flashing firmware...");
+                    Console.Write($"Flashing firmware...");
                 }
 
                 // write to flash
@@ -435,8 +435,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     if (verbosity >= VerbosityLevel.Normal)
                     {
+                        Console.Write($"Flashing firmware...");
+
                         Console.ForegroundColor = ConsoleColor.Green;
-                        Console.WriteLine("OK                            ");
+                        Console.WriteLine("OK".PadRight(110));
 
                         // warn user if reboot is not possible
                         if (espTool.CouldntResetTarget)

--- a/nanoFirmwareFlasher.Library/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher.Library/FirmwarePackage.cs
@@ -599,7 +599,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     return new DownloadUrlResult(string.Empty, string.Empty, ExitCodes.E9005);
                 }
 
-                if (verbosity > VerbosityLevel.Quiet)
+                if (verbosity >= VerbosityLevel.Detailed)
                 {
                     Console.ForegroundColor = ConsoleColor.Green;
                     Console.WriteLine($"OK");


### PR DESCRIPTION
## Description
- ESP32 flash write operations now have a perfect output.
- Remove output of ESP32 flash hash and extra output.
- Fix some conditions that where wrong when outputting progress.

## Motivation and Context
- Progress of ESP32 flash write wasn't perfect as the final OK was never on the same line.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
