### PR TITLE
Fix chip type name for ESP32-S3

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Firmware.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Firmware.cs
@@ -83,7 +83,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 FlashPartitions = new Dictionary<int, string>
                 {
 				    // bootloader goes to 0x1000, except for ESP32_C3 and ESP32_S3, which goes to 0x0
-				    { deviceInfo.ChipType == "ESP32-C3" || deviceInfo.ChipType == "ESP32-SC3" ? 0x0 : 0x1000, Path.Combine(LocationPath, BootloaderPath) },
+				    { deviceInfo.ChipType == "ESP32-C3" || deviceInfo.ChipType == "ESP32-S3" ? 0x0 : 0x1000, Path.Combine(LocationPath, BootloaderPath) },
 
 				    // nanoCLR goes to 0x10000
 				    { CLRAddress, Path.Combine(LocationPath, "nanoCLR.bin") },

--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -286,8 +286,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // compose bootloader partition
             var bootloaderPartition = new Dictionary<int, string>
             {
-				// bootloader goes to 0x1000
-				{ 0x1000, Path.Combine(Utilities.ExecutingPath, $"{_chipType}bootloader", "bootloader.bin") },
+                // bootloader goes to 0x1000, except for ESP32_C3 and ESP32_S3, which goes to 0x0
+				{ _chipType == "esp32c3" || _chipType == "esp32s3" ? 0x0 : 0x1000, Path.Combine(Utilities.ExecutingPath, $"{_chipType}bootloader", "bootloader.bin") },
 
 				// nanoCLR goes to 0x10000
 				{ 0x10000, Path.Combine(Utilities.ExecutingPath, $"{_chipType}bootloader", "test_startup.bin") },


### PR DESCRIPTION
## Description
- Fix chip type name for ESP32-S3.

## Motivation and Context
- String with name was wrong in a couple of places thus making the code fail.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
