### PR TITLE
Fix ESP32 revision parsing

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Operations.cs
@@ -145,19 +145,25 @@ namespace nanoFramework.Tools.FirmwareFlasher
             {
                 if (esp32Device.ChipType == "ESP32")
                 {
+                    // version schema for ESP32
+                    //Previously Used Schemes | Previous Identification   | vM.X
+                    //            V0          |           0               | v0.0
+                    //         ECO, V1        |           1               | v1.0
+                    //         ECO, V3        |           3               | v3.0
+
                     if (esp32Device.ChipName.Contains("PICO"))
                     {
                         targetName = "ESP32_PICO";
                     }
                     else
                     {
-                        var revisionSuffix = "REV0";
+                        var revisionSuffix = "_REV0";
                         var psRamSegment = "";
                         var otherSegment = "";
 
-                        if (esp32Device.ChipName.Contains("revision 3"))
+                        if (esp32Device.ChipName.Contains("revision v3"))
                         {
-                            revisionSuffix = "REV3";
+                            revisionSuffix = "_REV3";
                         }
 
                         if (esp32Device.PSRamAvailable == PSRamAvailability.Yes)
@@ -174,28 +180,51 @@ namespace nanoFramework.Tools.FirmwareFlasher
                             psRamSegment = "_PSRAM";
 
                             // also need to force rev0 even if that's higher
-                            revisionSuffix = "REV0";
-                        }
-
-                        if (esp32Device.ChipName.Contains("ESP32_C3"))
-                        {
-                            if (esp32Device.ChipName.Contains("revision 2"))
-                            {
-                                revisionSuffix = "REV2";
-                            }
-                            else
-                            {
-                                // all the others (rev3 and rev4) will take rev3
-                                revisionSuffix = "REV3";
-                            }
+                            revisionSuffix = "_REV0";
                         }
 
                         // compose target name
-                        targetName = $"ESP32{psRamSegment}{otherSegment}_{revisionSuffix}";
+                        targetName = $"ESP32{psRamSegment}{otherSegment}{revisionSuffix}";
+                    }
+
+                    if (fitCheck)
+                    {
+                        if (targetName.EndsWith("REV3") &&
+                            (esp32Device.ChipName.Contains("revision v0") ||
+                            esp32Device.ChipName.Contains("revision v1") ||
+                            esp32Device.ChipName.Contains("revision v2")))
+                        {
+                            // trying to use a target that's not compatible with the connected device 
+                            Console.ForegroundColor = ConsoleColor.Yellow;
+                            Console.WriteLine("");
+                            Console.WriteLine("***************************************** WARNING ****************************************");
+                            Console.WriteLine("Seems that the firmware image that's about to be used is for a revision 3 device, but the");
+                            Console.WriteLine($"connected device is {esp32Device.ChipName}.");
+                            Console.WriteLine("******************************************************************************************");
+                            Console.WriteLine("");
+                        }
+
+                        if (targetName.Contains("BLE") &&
+                            !esp32Device.Features.Contains(", BT,"))
+                        {
+                            // trying to use a traget with BT and the connected device doens't have support for it
+                            Console.ForegroundColor = ConsoleColor.Yellow;
+                            Console.WriteLine("");
+                            Console.WriteLine("******************************************* WARNING *******************************************");
+                            Console.WriteLine("Seems that the firmware image that's about to be used includes Bluetooth features, but the");
+                            Console.WriteLine($"connected device does not have support for it. You should use a target without BLE in the name.");
+                            Console.WriteLine("************************************************************************************************");
+                            Console.WriteLine("");
+                        }
                     }
                 }
                 else if (esp32Device.ChipType == "ESP32-S2")
                 {
+                    // version schema for ESP32-S2
+                    //Previously Used Schemes | Previous Identification   | vM.X
+                    //           n/a          |           0               | v0.0
+                    //           ECO1         |           1               | v1.0
+
                     // can't guess with certainty for this series, better request a target name to the user
 
                     Console.ForegroundColor = ConsoleColor.Red;
@@ -211,16 +240,23 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
                 else if (esp32Device.ChipType == "ESP32-C3")
                 {
+                    // version schema for ESP32-C3
+                    //Previously Used Schemes | Previous Identification   | vM.X
+                    //     Chip Revision 2    |           2               | v0.2
+                    //     Chip Revision 3    |           3               | v0.3
+                    //     Chip Revision 4    |           4               | v0.4
+
                     string revisionSuffix;
 
-                    if (esp32Device.ChipName.Contains("revision 2"))
+                    if (esp32Device.ChipName.Contains("revision v0.2"))
                     {
-                        revisionSuffix = "REV2";
+                        // this is the "default" one we're offering
+                        revisionSuffix = "";
                     }
-                    else if (esp32Device.ChipName.Contains("revision 3") || esp32Device.ChipName.Contains("revision 4"))
+                    else if (esp32Device.ChipName.Contains("revision v0.3") || esp32Device.ChipName.Contains("revision v0.4"))
                     {
                         // all the others (rev3 and rev4) will take rev3
-                        revisionSuffix = "REV3";
+                        revisionSuffix = "_REV3";
                     }
                     else
                     {
@@ -236,14 +272,37 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     }
 
                     // compose target name
-                    targetName = $"ESP32_C3_{revisionSuffix}";
+                    targetName = $"ESP32_C3{revisionSuffix}";
                 }
                 else if (esp32Device.ChipType == "ESP32-S3")
                 {
-                    // ESP32_S3 has only one revision
+                    // version schema for ESP32-S3
+                    //Previously Used Schemes | Previous Identification   | vM.X
+                    //          V001          |     0 (bug in logs)       | v0.1
+                    //          V002          |           n/a             | v0.2
+
+                    string revisionSuffix;
+
+                    // so far we are only offering a single ESP32_S3 build
+                    if (esp32Device.ChipName.Contains("revision 0.1") || esp32Device.ChipName.Contains("revision 0.2"))
+                    {
+                        revisionSuffix = "";
+                    }
+                    else
+                    {
+                        Console.ForegroundColor = ConsoleColor.Red;
+
+                        Console.WriteLine("");
+                        Console.WriteLine($"Unsupported ESP32_S3 revision.");
+                        Console.WriteLine("");
+
+                        Console.ForegroundColor = ConsoleColor.White;
+
+                        return ExitCodes.E9000;
+                    }
 
                     // compose target name
-                    targetName = $"ESP32_S3";
+                    targetName = $"ESP32_S3{revisionSuffix}";
                 }
 
                 Console.ForegroundColor = ConsoleColor.Blue;
@@ -253,37 +312,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 Console.WriteLine("");
 
                 Console.ForegroundColor = ConsoleColor.White;
-            }
-
-            if (fitCheck)
-            {
-                if (targetName.EndsWith("REV3") &&
-                    (esp32Device.ChipName.Contains("revision 0") ||
-                    esp32Device.ChipName.Contains("revision 1") ||
-                    esp32Device.ChipName.Contains("revision 2")))
-                {
-                    // trying to use a target that's not compatible with the connected device 
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.WriteLine("");
-                    Console.WriteLine("***************************************** WARNING ****************************************");
-                    Console.WriteLine("Seems that the firmware image that's about to be used is for a revision 3 device, but the");
-                    Console.WriteLine($"connected device is {esp32Device.ChipName}.");
-                    Console.WriteLine("******************************************************************************************");
-                    Console.WriteLine("");
-                }
-
-                if (targetName.Contains("BLE") &&
-                    !esp32Device.Features.Contains(", BT,"))
-                {
-                    // trying to use a traget with BT and the connected device doens't have support for it
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.WriteLine("");
-                    Console.WriteLine("******************************************* WARNING *******************************************");
-                    Console.WriteLine("Seems that the firmware image that's about to be used includes Bluetooth features, but the");
-                    Console.WriteLine($"connected device does not have support for it. You should use a target without BLE in the name.");
-                    Console.WriteLine("************************************************************************************************");
-                    Console.WriteLine("");
-                }
             }
 
             Esp32Firmware firmware = new Esp32Firmware(


### PR DESCRIPTION
## Description
- Add different handling for each series.
- Add notes with known version format.
- Minor improvements in revision string to be coherent across series.
- Moved fit check to ESP32 only.

## Motivation and Context
- Reported revision format from esptool has changed.
- There were inconsistencies in the revision parsing the code was doing when compared with IDF version schema for some series.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
