### PR TITLE
Add NESHTEC board to platform check

### DIFF
--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -480,6 +480,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     || o.TargetName.StartsWith("WeAct")
                     || o.TargetName.StartsWith("ORGPAL")
                     || o.TargetName.StartsWith("Pyb")
+                    || o.TargetName.StartsWith("NESHTEC_NESHNODE_V")
                 )
                 {
                     // candidates for STM32


### PR DESCRIPTION
The tool will crash with an undefined behaviour otherwise

I strongly suggest to rework that autodetetion part. It should at least pull some dynamic data source and not rely on hardcoded values. Could also be solved within the build pipeline, e.g. by generating a small config file. This way, nanoff will still work offline.

## Description
Debugged the behavior and added the new STM32 community target to the platform autodetection function.

## Motivation and Context
Flashing using nanoff wasn't possible to an 'unknown' board

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Debugged, tested and discussed with @josesimoes 

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
