### PR TITLE
Allow either bin or hex file to be used for STM32 DFU update

### DIFF
--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -883,9 +883,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 var connectedStDfuDevices = StmDfuDevice.ListDevices();
                 var connectedStJtagDevices = StmJtagDevice.ListDevices();
 
-                if (o.BinFile.Any() &&
-                    o.HexFile.Any() &&
-                    connectedStDfuDevices.Count != 0)
+                if (connectedStDfuDevices.Count != 0 &&
+                    (o.BinFile.Any() ||
+                     o.HexFile.Any()))
                 {
 
                     #region STM32 DFU options
@@ -940,11 +940,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     #endregion
 
                 }
-                else if (
-                    o.BinFile.Any() &&
-                    o.HexFile.Any() &&
-                    connectedStJtagDevices.Count != 0
-                     )
+                else if (connectedStJtagDevices.Count != 0 &&
+                        (o.BinFile.Any() ||
+                         o.HexFile.Any()))
                 {
                     // this has to be a JTAG connected device
 


### PR DESCRIPTION
## Description

* Unable to flash a STM32 board with Bin or Hex file.

## Motivation and Context

* When trying to flash a STM32 board with a Bin file nothing happens.
* It's because the code was testing presence for both BinFiles array and HexFiles array, instead of a `OR` comparison.

## How Has This Been Tested?

* Tested by debug run and command line provision.

## Types of changes

- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:

- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
