### PR TITLE
Fix deployment operation with J-Link

### DIFF
--- a/nanoFirmwareFlasher.Library/JLinkCli.cs
+++ b/nanoFirmwareFlasher.Library/JLinkCli.cs
@@ -222,12 +222,12 @@ Exit
                 DoMassErase = false;
             }
 
-            if (Verbosity < VerbosityLevel.Normal)
+            if (Verbosity == VerbosityLevel.Normal)
             {
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.Write("Flashing device...");
             }
-            else
+            else if (Verbosity >= VerbosityLevel.Detailed)
             {
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.WriteLine("Flashing device...");
@@ -235,6 +235,8 @@ Exit
 
             // program BIN file(s)
             int index = 0;
+            bool warningPromptShown = false;
+
             foreach (string binFile in shadowFiles)
             {
                 // make sure path is absolute
@@ -265,7 +267,14 @@ Exit
                 if (Verbosity >= VerbosityLevel.Normal
                     && cliOutput.Contains("Skipped. Contents already match"))
                 {
+                    warningPromptShown = true;
+
                     Console.ForegroundColor = ConsoleColor.Yellow;
+
+                    if (Verbosity == VerbosityLevel.Normal)
+                    {
+                        Console.WriteLine();
+                    }
 
                     Console.WriteLine("");
                     Console.WriteLine("******************* WARNING *********************");
@@ -286,12 +295,15 @@ Exit
                 ShowCLIOutput(cliOutput);
             }
 
-            if (Verbosity < VerbosityLevel.Normal)
+            if (Verbosity == VerbosityLevel.Normal)
             {
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine(" OK");
+                if (!warningPromptShown)
+                {
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.WriteLine(" OK");
+                }
             }
-            else
+            else if (Verbosity >= VerbosityLevel.Detailed)
             {
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.WriteLine("Flashing completed...");
@@ -360,12 +372,12 @@ Exit
                 DoMassErase = false;
             }
 
-            if (Verbosity < VerbosityLevel.Normal)
+            if (Verbosity == VerbosityLevel.Normal)
             {
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.Write("Flashing device...");
             }
-            else
+            else if (Verbosity >= VerbosityLevel.Detailed)
             {
                 Console.ForegroundColor = ConsoleColor.White;
                 Console.WriteLine("Flashing device...");
@@ -409,10 +421,19 @@ Exit
             // OK to delete the JLink command file
             File.Delete(jlinkCmdFilePath);
 
+            bool warningPromptShown = false;
+
             if (Verbosity >= VerbosityLevel.Normal
                 && cliOutput.Contains("Skipped. Contents already match"))
             {
+                warningPromptShown = true;
+
                 Console.ForegroundColor = ConsoleColor.Yellow;
+
+                if (Verbosity == VerbosityLevel.Normal)
+                {
+                    Console.WriteLine();
+                }
 
                 Console.WriteLine("");
                 Console.WriteLine("******************* WARNING *********************");
@@ -432,12 +453,15 @@ Exit
 
             ShowCLIOutput(cliOutput);
 
-            if (Verbosity < VerbosityLevel.Normal)
+            if (Verbosity == VerbosityLevel.Normal)
             {
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine(" OK");
+                if (!warningPromptShown)
+                {
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.WriteLine(" OK");
+                }
             }
-            else
+            else if (Verbosity >= VerbosityLevel.Detailed)
             {
                 Console.ForegroundColor = ConsoleColor.Green;
                 Console.WriteLine("Flashing completed...");


### PR DESCRIPTION
## Description
- Fix check for deployment image in options.
- Add missing processing for stand alone deploy operation.
- Rework prompts for flashing bin and hex files. Now sequence is correct and coherent.

## Motivation and Context
- Deployment of bin file wasn't working.
- Prompts for JLink operations were misplaced or garbled when flash content matched the new content.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
