### PR TITLE
Fix output of device operations

### DIFF
--- a/nanoFirmwareFlasher.Tool/NanoDeviceManager.cs
+++ b/nanoFirmwareFlasher.Tool/NanoDeviceManager.cs
@@ -29,6 +29,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <inheritdoc />
         public async Task<ExitCodes> ProcessAsync()
         {
+            bool failedToDoSomething = true;
+            ExitCodes exitCode = ExitCodes.OK;
+
             // COM port is mandatory for nano device operations
             if (string.IsNullOrEmpty(_options.SerialPort))
             {
@@ -46,7 +49,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
             else if (_options.Update)
             {
-                var exitCode = await _nanoDeviceOperations.UpdateDeviceClrAsync(
+                exitCode = await _nanoDeviceOperations.UpdateDeviceClrAsync(
                     _options.SerialPort,
                     _options.FwVersion,
                     _options.ClrFile,
@@ -56,11 +59,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     return exitCode;
                 }
+
+                // flag operation as done
+                failedToDoSomething = false;
             }
 
             if (_options.Deploy)
             {
-                var exitCode = _nanoDeviceOperations.DeployApplication(
+                exitCode = _nanoDeviceOperations.DeployApplication(
                     _options.SerialPort,
                     _options.DeploymentImage,
                     _verbosityLevel);
@@ -69,9 +75,17 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     return exitCode;
                 }
+
+                // flag operation as done
+                failedToDoSomething = false;
             }
 
-            throw new NoOperationPerformedException();
+            if (failedToDoSomething)
+            {
+                throw new NoOperationPerformedException();
+            }
+
+            return exitCode;
         }
     }
 }

--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -364,29 +364,31 @@ namespace nanoFramework.Tools.FirmwareFlasher
             {
                 var manager = new NanoDeviceManager(o, _verbosityLevel);
 
-                try
-                {
-                    _exitCode = await manager.ProcessAsync();
-                }
-                catch (CantConnectToNanoDeviceException ex)
-                {
-                    _exitCode = ExitCodes.E2001;
-                    _extraMessage = ex.Message;
-                }
-                catch (NoOperationPerformedException)
-                {
-                    DisplayNoOperationMessage();
-                }
-                catch (Exception ex)
-                {
-                    _exitCode = ExitCodes.E2002;
-                    _extraMessage = ex.Message;
-                }
-
                 // COM port is mandatory for nano device operations
                 if (string.IsNullOrEmpty(o.SerialPort))
                 {
                     _exitCode = ExitCodes.E6001;
+                }
+                else
+                {
+                    try
+                    {
+                        _exitCode = await manager.ProcessAsync();
+                    }
+                    catch (CantConnectToNanoDeviceException ex)
+                    {
+                        _exitCode = ExitCodes.E2001;
+                        _extraMessage = ex.Message;
+                    }
+                    catch (NoOperationPerformedException)
+                    {
+                        DisplayNoOperationMessage();
+                    }
+                    catch (Exception ex)
+                    {
+                        _exitCode = ExitCodes.E2002;
+                        _extraMessage = ex.Message;
+                    }
                 }
 
                 return;


### PR DESCRIPTION
## Description
- Add flag to check for any operation performed.
- Move check for missing serial port parameter to the beginning of the device operations.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
