### PR TITLE
Tiny ExitCode spelling error fixes

### DIFF
--- a/nanoFirmwareFlasher.Library/ExitCodes.cs
+++ b/nanoFirmwareFlasher.Library/ExitCodes.cs
@@ -36,7 +36,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         E1002 = 1002,
 
         /// <summary>
-        /// Error flashing DFU dvice
+        /// Error flashing DFU device
         /// </summary>
         [Display(Name = "Error flashing DFU device.")]
         E1003 = 1003,
@@ -56,7 +56,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <summary>
         /// Failed to start execution on the connected device.
         /// </summary>
-        [Display(Name = "Failed to start execition on the connected device.")]
+        [Display(Name = "Failed to start execution on the connected device.")]
         E1006 = 1006,
 
         ///////////////////////
@@ -318,7 +318,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <summary>
         /// CLR image file has wrong format. It has to be a binary file.
         /// </summary>
-        [Display(Name = "CLR image file has wrong format.It has to be a binary file.")]
+        [Display(Name = "CLR image file has wrong format. It has to be a binary file.")]
         E9012 = 9012,
 
         /// <summary>


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Fixed some minor spelling errors in exit codes

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
