### PR TITLE
Rework telemetry client

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -330,8 +330,8 @@ jobs:
   # Replace the intrument key
   - powershell: |
           . ./common.ps1
-          $fileToReplace = "$(System.DefaultWorkingDirectory)/nanoFirmwareFlasher.Library/appsettings.json"
-          $sourceString = "INTRUMENT_KEY"
+          $fileToReplace = "$(System.DefaultWorkingDirectory)/nanoFirmwareFlasher.Tool\appsettings.json"
+          $sourceString = "INSTRUMENT_KEY"
           $instrumentKey = "$(InstrumentKey)"
 
           Find-ReplaceInFile -filePath $fileToReplace -sourceString $sourceString -targetString $instrumentKey

--- a/nanoFirmwareFlasher.Library/NanoTelemetryClient.cs
+++ b/nanoFirmwareFlasher.Library/NanoTelemetryClient.cs
@@ -1,0 +1,61 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using Microsoft.ApplicationInsights;
+using System;
+
+namespace nanoFramework.Tools.FirmwareFlasher
+{
+    /// <summary>
+    /// Telemetry client for sending telemetry data to Application Insights.
+    /// </summary>
+    public class NanoTelemetryClient
+    {
+        private static TelemetryClient _myTelemetryClient;
+
+        // flag to signal that the telemetry client field initialized has been processed
+        private static bool notProcessed = true;
+
+        /// <summary>
+        /// Connection string for <see cref="TelemetryClient"/>.
+        /// </summary>
+        public static string ConnectionString;
+
+        /// <summary>
+        /// Gets the <see cref="TelemetryClient"/> to use for sending telemetry data.
+        /// </summary>
+        public static TelemetryClient TelemetryClient => GetTelemetryClient();
+
+        private static TelemetryClient GetTelemetryClient()
+        {
+            if (notProcessed && _myTelemetryClient is null)
+            {
+                string optOutTelemetry = Environment.GetEnvironmentVariable("NANOFRAMEWORK_TELEMETRY_OPTOUT");
+
+                if (!string.IsNullOrEmpty(ConnectionString)
+                    && (optOutTelemetry is null || optOutTelemetry != "1"))
+                {
+                    // parsing the connection string could fail
+                    try
+                    {
+                        _myTelemetryClient = new TelemetryClient(new Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration()
+                        {
+                            ConnectionString = ConnectionString
+                        });
+                    }
+                    catch
+                    {
+                        // don't care, telemetry is not mandatory
+                    };
+                }
+
+                // set flag to false to signal that the telemetry client field has been processed
+                notProcessed = false;
+            }
+
+            return _myTelemetryClient;
+        }
+    }
+}

--- a/nanoFirmwareFlasher.Library/nanoFirmwareFlasher.Library.csproj
+++ b/nanoFirmwareFlasher.Library/nanoFirmwareFlasher.Library.csproj
@@ -127,10 +127,5 @@
         <None Include="..\lib\uniflash\**" Link="uniflash\%(RecursiveDir)%(Filename)%(Extension)">
         </None>
     </ItemGroup>
-    <ItemGroup>
-      <None Update="appsettings.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
 
 </Project>

--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -5,7 +5,7 @@
 
 using CommandLine;
 using CommandLine.Text;
-using nanoFramework.Tools.Debugger;
+using Microsoft.Extensions.Configuration;
 using nanoFramework.Tools.FirmwareFlasher.Extensions;
 using Newtonsoft.Json;
 using System;
@@ -17,7 +17,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace nanoFramework.Tools.FirmwareFlasher
@@ -50,6 +49,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
             string codeBase = Assembly.GetExecutingAssembly().Location;
             var fullPath = Path.GetFullPath(codeBase);
             ExecutingPath = Path.GetDirectoryName(fullPath);
+
+            // grab AppInsights connection string to setup telemetry client
+            IConfigurationRoot appConfigurationRoot = new ConfigurationBuilder()
+                .SetBasePath(ExecutingPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .Build();
+
+            NanoTelemetryClient.ConnectionString = appConfigurationRoot?["iConnectionString"];
 
             // check for empty argument collection
             if (!args.Any())

--- a/nanoFirmwareFlasher.Tool/appsettings.json
+++ b/nanoFirmwareFlasher.Tool/appsettings.json
@@ -1,3 +1,3 @@
 {
-  "iConnectionString": "INTRUMENT_KEY"
+  "iConnectionString": "INSTRUMENT_KEY"
 }

--- a/nanoFirmwareFlasher.Tool/appsettings.json
+++ b/nanoFirmwareFlasher.Tool/appsettings.json
@@ -1,4 +1,3 @@
 {
   "iConnectionString": "INTRUMENT_KEY"
-
 }

--- a/nanoFirmwareFlasher.Tool/nanoFirmwareFlasher.Tool.csproj
+++ b/nanoFirmwareFlasher.Tool/nanoFirmwareFlasher.Tool.csproj
@@ -69,6 +69,12 @@
 	  <ProjectReference Include="..\nanoFirmwareFlasher.Library\nanoFirmwareFlasher.Library.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <None Update="appsettings.json">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
+
 	<Target Name="CopyToolsContent" AfterTargets="Build">
 	    <ItemGroup>
             <LibSourceFiles Include="$(MSBuildThisFileDirectory)\..\lib\**\*.*" />


### PR DESCRIPTION
## Description
- Move it to static class so it can be reused.
- Now accepting AppInsights connection string directly.
- App settings moved to tool project.
- Fix path to grab appsettings from.
- Update code accordingly.
- Fix typo in setting name.

## Motivation and Context
- Path to appsettings file has to be deal differently because this is a .NET tool.
- Better to have a TelemetryClient class available in the library to allow reuse when adding more instrumentation points.
- Fixes nanoFramework/Home#1418.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running debug version with calls to several targets and operations.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
