### PR TITLE
Improve update operation for ESP32

### DIFF
--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -394,6 +394,44 @@ namespace nanoFramework.Tools.FirmwareFlasher
         }
 
         /// <summary>
+        /// Backup the entire flash into a bin file
+        /// </summary>
+        /// <param name="backupFilename">Backup file including full path</param>
+        /// <param name="address">Start address of the config partition.</param>
+        /// <param name="size">Size of the config partition.</param>
+        /// <returns>true if successful</returns>
+        internal ExitCodes BackupConfigPartition(
+            string backupFilename,
+            int address,
+            int size)
+        {
+            // execute dump_mem  command and parse the result; progress message can be found be searching for backspaces (ASCII code 8)
+            if (!RunEspTool(
+                $"read_flash 0x{address:X} 0x{size:X} \"{backupFilename}\"",
+                false,
+                true,
+                false,
+                null,
+                out string messages))
+            {
+                throw new ReadEsp32FlashException(messages);
+            }
+
+            var match = Regex.Match(messages, "(?<message>Read .*)(.*?\n)*");
+            if (!match.Success)
+            {
+                throw new ReadEsp32FlashException(messages);
+            }
+
+            if (Verbosity >= VerbosityLevel.Detailed)
+            {
+                Console.WriteLine(match.Groups["message"].ToString().Trim());
+            }
+
+            return ExitCodes.OK;
+        }
+
+        /// <summary>
         /// Erase the entire flash of the ESP32 chip.
         /// </summary>
         /// <returns>true if successful</returns>

--- a/nanoFirmwareFlasher.Library/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher.Library/FirmwarePackage.cs
@@ -293,6 +293,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             filesToDelete.AddRange(Directory.EnumerateFiles(LocationPath, "*.hex").ToList());
             filesToDelete.AddRange(Directory.EnumerateFiles(LocationPath, "*.s19").ToList());
             filesToDelete.AddRange(Directory.EnumerateFiles(LocationPath, "*.dfu").ToList());
+            filesToDelete.AddRange(Directory.EnumerateFiles(LocationPath, "*.csv").ToList());
 
             foreach (var file in filesToDelete)
             {

--- a/nanoFirmwareFlasher.Tool/Esp32Manager.cs
+++ b/nanoFirmwareFlasher.Tool/Esp32Manager.cs
@@ -145,6 +145,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     null,
                     _options.ClrFile,
                     !_options.FitCheck,
+                    _options.MassErase,
                     _verbosityLevel,
                     _options.Esp32PartitionTableSize);
 
@@ -182,6 +183,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     appFlashAddress,
                     null,
                     !_options.FitCheck,
+                    _options.MassErase,
                     _verbosityLevel,
                     _options.Esp32PartitionTableSize);
 


### PR DESCRIPTION
## Description
- Command workflow now honors masserase option.
- Config partition is now restored previous to update and then written back along with update.

## Motivation and Context
- Update operation on ESP32 was completely wiping the flash on update when it shouldn't.
- The config partition contains data that is user dependent and formatting it during an update called for adding back Wi-Fi profiles, certs and such. From now on all that data is preserved.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
