### PR TITLE
Improve deployment operation for ESP32

### DIFF
--- a/nanoFirmwareFlasher.Tool/Esp32Manager.cs
+++ b/nanoFirmwareFlasher.Tool/Esp32Manager.cs
@@ -158,8 +158,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 updateAndDeploy = true;
             }
 
-            // it's OK to deploy after a successful update
-            if (_options.Deploy)
+            // deploy without update
+            if (_options.Deploy && !_options.Update)
             {
                 // need to take care of flash address
                 string appFlashAddress = string.Empty;
@@ -172,18 +172,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                 // this to flash a deployment image without updating the firmware
                 // write flash
-                var exitCode = await Esp32Operations.UpdateFirmwareAsync(
+                var exitCode = await Esp32Operations.DeployApplicationAsync(
                     espTool,
                     esp32Device,
                     _options.TargetName,
-                    false,
-                    null,
-                    false,
                     _options.DeploymentImage,
                     appFlashAddress,
-                    null,
-                    !_options.FitCheck,
-                    _options.MassErase,
                     _verbosityLevel,
                     _options.Esp32PartitionTableSize);
 


### PR DESCRIPTION
## Description
- Extract method to allow flashing deploying only operation.
- Improve code in update device to properly add deployment partition if needed.
- Fix check to perform deployment operation only. Doesn't occur after update anymore.

## Motivation and Context
- Allows deploying to ESP32 partition as part of the update process and separately from it.
- Fixes nanoframework/Home#1423.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
