### PR TITLE
PSRAM discovery is now performed for all targets

### DIFF
--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -246,19 +246,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 // FEATHER_S2's have PSRAM, so don't even bother
                 psramIsAvailable = PSRamAvailability.Yes;
             }
-            else if (name.Contains("ESP32-C3")
-                     || name.Contains("ESP32-S3"))
-            {
-                // all ESP32-C3/S3 SDK config have support for PSRAM, so don't even bother
-                psramIsAvailable = PSRamAvailability.Undetermined;
-            }
             else
             {
                 // if a target name wasn't provided, check for PSRAM
-                // except for ESP32_C3 and S3
-                if (targetName == null
-                    && !name.Contains("ESP32-C3")
-                    && !name.Contains("ESP32-S3"))
+                if (targetName == null)
                 {
                     psramIsAvailable = FindPSRamAvailable();
                 }


### PR DESCRIPTION

## Description
- Change code to perform PSRAM discovery for all targets, except the one reportedly not having support for it or the ones which always have it.

## Motivation and Context
- Clear potentially confusing messaging about PSRAM being undertemined.
- Preparation for move to IDF 5.x which bring support for other series and new SDk configs which include variants for S3 and C3 that do not include support for PSRAM.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
