### PR TITLE
Fix issues with file paths for GGecko updates

### DIFF
--- a/nanoFirmwareFlasher.Library/JLinkCli.cs
+++ b/nanoFirmwareFlasher.Library/JLinkCli.cs
@@ -179,34 +179,9 @@ Exit
                 }
             }
 
-            List<string> shadowFiles = new List<string>();
+            List<string> shadowFiles = [];
 
-            // J-Link can't handle diacritc chars
-            // developer note: reported to Segger (Case: 60276735) and can be removed if this is fixed/improved
-            foreach (string binFile in files)
-            {
-                if (!binFile.IsNormalized(NormalizationForm.FormD)
-                    || binFile.Contains(' '))
-                {
-                    var tempFile = Path.Combine(
-                        Environment.GetEnvironmentVariable("TEMP", EnvironmentVariableTarget.Machine),
-                        Path.GetFileName(binFile));
-
-                    // copy file to shadow file
-                    File.Copy(
-                        binFile,
-                        tempFile,
-                        true);
-
-                    shadowFiles.Add(tempFile);
-                }
-                else
-                {
-                    // copy file to shadow list
-                    shadowFiles.Add(binFile);
-                }
-
-            }
+            ProcessFilePaths(files, shadowFiles);
 
             // erase flash
             if (DoMassErase)
@@ -239,19 +214,14 @@ Exit
 
             foreach (string binFile in shadowFiles)
             {
-                // make sure path is absolute
-                var binFilePath = Utilities.MakePathAbsolute(
-                    Environment.CurrentDirectory,
-                    binFile);
-
                 if (Verbosity > VerbosityLevel.Normal)
                 {
                     Console.ForegroundColor = ConsoleColor.Cyan;
-                    Console.WriteLine($"{Path.GetFileName(binFilePath)} @ {addresses.ElementAt(index)}");
+                    Console.WriteLine($"{Path.GetFileName(binFile)} @ {addresses.ElementAt(index)}");
                 }
 
                 // compose JLink command file
-                var jlinkCmdContent = FlashSingleFileCommandTemplate.Replace(FilePathToken, binFilePath).Replace(FlashAddressToken, addresses.ElementAt(index++));
+                var jlinkCmdContent = FlashSingleFileCommandTemplate.Replace(FilePathToken, binFile).Replace(FlashAddressToken, addresses.ElementAt(index++));
                 var jlinkCmdFilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.jlink");
 
                 // create file
@@ -314,6 +284,41 @@ Exit
             return ExitCodes.OK;
         }
 
+        private void ProcessFilePaths(IList<string> files, List<string> shadowFiles)
+        {
+            // J-Link can't handle diacritc chars
+            // developer note: reported to Segger (Case: 60276735) and can be removed if this is fixed/improved
+            foreach (string binFile in files)
+            {
+                // make sure path is absolute
+                var binFilePath = Utilities.MakePathAbsolute(
+                    Environment.CurrentDirectory,
+                    binFile);
+
+                if (!binFilePath.IsNormalized(NormalizationForm.FormD)
+                    || binFilePath.Contains(' '))
+                {
+                    var tempFile = Path.Combine(
+                        Environment.GetEnvironmentVariable("TEMP", EnvironmentVariableTarget.Machine),
+                        Path.GetFileName(binFilePath));
+
+                    // copy file to shadow file
+                    File.Copy(
+                        binFilePath,
+                        tempFile,
+                        true);
+
+                    shadowFiles.Add(tempFile);
+                }
+                else
+                {
+                    // copy file to shadow list
+                    shadowFiles.Add(binFile);
+                }
+
+            }
+        }
+
         /// <summary>
         /// Executes an operation that flashes a collection of Intel HEX format files to a connected J-Link device.
         /// </summary>
@@ -330,33 +335,9 @@ Exit
                 return ExitCodes.E5004;
             }
 
-            List<string> shadowFiles = new List<string>();
+            List<string> shadowFiles = [];
 
-            // J-Link can't handle diacritc chars
-            // developer note: reported to Segger (Case: 60276735) and can be removed if this is fixed/improved
-            foreach (string hexFile in files)
-            {
-                if (!hexFile.IsNormalized(NormalizationForm.FormD) ||
-                    hexFile.Contains(' '))
-                {
-                    var tempFile = Path.Combine(
-                        Environment.GetEnvironmentVariable("TEMP", EnvironmentVariableTarget.Machine),
-                        Path.GetFileName(hexFile));
-
-                    // copy file to shadow file
-                    File.Copy(
-                        hexFile,
-                        tempFile,
-                        true);
-
-                    shadowFiles.Add(tempFile);
-                }
-                else
-                {
-                    // copy file to shadow list
-                    shadowFiles.Add(hexFile);
-                }
-            }
+            ProcessFilePaths(files, shadowFiles);
 
             // erase flash
             if (DoMassErase)
@@ -388,18 +369,13 @@ Exit
 
             foreach (string hexFile in shadowFiles)
             {
-                // make sure path is absolute
-                var hexFilePath = Utilities.MakePathAbsolute(
-                    Environment.CurrentDirectory,
-                    hexFile);
-
                 if (Verbosity > VerbosityLevel.Normal)
                 {
                     Console.ForegroundColor = ConsoleColor.Cyan;
-                    Console.WriteLine($"{Path.GetFileName(hexFilePath)}");
+                    Console.WriteLine($"{Path.GetFileName(hexFile)}");
                 }
 
-                listOfFiles.AppendLine($"LoadFile {hexFilePath}");
+                listOfFiles.AppendLine($"LoadFile {hexFile}");
             }
 
             // compose JLink command file


### PR DESCRIPTION
## Description
- Check for absolute path was move upwards.
- Now check for diacritc chars in path is handled after absolute path transformation.
- Move path processing to a new method and replace calls.

## Motivation and Context
- Flashing a GG11 device with a binary file without full path being specified was failing.
- Following DRY and general simplification of path check and transformation.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
