### PR TITLE
Revert "PSRAM discovery is now performed for all targets (#264)"

### DIFF
--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -246,10 +246,19 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 // FEATHER_S2's have PSRAM, so don't even bother
                 psramIsAvailable = PSRamAvailability.Yes;
             }
+            else if (name.Contains("ESP32-C3")
+                     || name.Contains("ESP32-S3"))
+            {
+                // all ESP32-C3/S3 SDK config have support for PSRAM, so don't even bother
+                psramIsAvailable = PSRamAvailability.Undetermined;
+            }
             else
             {
                 // if a target name wasn't provided, check for PSRAM
-                if (targetName == null)
+                // except for ESP32_C3 and S3
+                if (targetName == null
+                    && !name.Contains("ESP32-C3")
+                    && !name.Contains("ESP32-S3"))
                 {
                     psramIsAvailable = FindPSRamAvailable();
                 }


### PR DESCRIPTION
This reverts commit cc982cd477105f0ef65abfd5c2e9e6dc6e6d299b.

<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
Revert "PSRAM discovery is now performed for all targets (#264)"

## Motivation and Context
- Fixes nanoframework/Home/issues/1481

It broke the tool for ESP32-S3 targets (and maybe others) because the `nanoFirmwareFlasher.Library` project does not contain a folder named "esp32s3bootloader" with the bootloader in it. 

The correct solution is to add the bootloader and associated files but I'm not familiar with that and just looking to get the tool working again ASAP.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Manual execution.

## Screenshots<!-- (IF APPROPRIATE): -->

![image](https://github.com/nanoframework/nanoFirmwareFlasher/assets/10094287/61c7417c-8d6d-4aa8-90f9-61293c527a71)

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
