### PR TITLE
Fix failed reporting of launching nanoBooter

### DIFF
--- a/nanoFirmwareFlasher.Library/NanoDeviceOperations.cs
+++ b/nanoFirmwareFlasher.Library/NanoDeviceOperations.cs
@@ -288,7 +288,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                         }
                     }
 
-                    bool attemptToLaunchBooter = false;
+                    bool booterLaunched = false;
 
                     if (nanoDevice.DebugEngine.IsConnectedTonanoCLR)
                     {
@@ -306,9 +306,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                                 Console.ForegroundColor = ConsoleColor.White;
                             }
 
-                            attemptToLaunchBooter = nanoDevice.ConnectToNanoBooter();
+                            booterLaunched = nanoDevice.ConnectToNanoBooter();
 
-                            if (!attemptToLaunchBooter)
+                            if (!booterLaunched)
                             {
                                 // check for version where the software reboot to nanoBooter was made available
                                 if (currentClrVersion != null &&
@@ -334,10 +334,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     }
                     else
                     {
-                        attemptToLaunchBooter = true;
+                        booterLaunched = true;
                     }
 
-                    if (attemptToLaunchBooter &&
+                    if (booterLaunched &&
                         nanoDevice.Ping() == Debugger.WireProtocol.ConnectionSource.nanoBooter)
                     {
                         // get address for CLR block expected by device
@@ -380,7 +380,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                                 }
                             }
 
-                            if (attemptToLaunchBooter)
+                            if (booterLaunched)
                             {
                                 // try to reboot target 
                                 if (verbosity >= VerbosityLevel.Normal)
@@ -408,7 +408,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     }
                     else
                     {
-                        if (attemptToLaunchBooter)
+                        if (!booterLaunched)
                         {
                             // only report this as an error if the launch was successful
                             throw new NanoDeviceOperationFailedException("Failed to launch nanoBooter. Quitting update.");


### PR DESCRIPTION
## Description
- Condition post launch were wrong. Now shows the correct message on failure.

## Motivation and Context
- Wans't reporting the failure to boot to nanoBooter.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
