### PR TITLE
Fix S3 broken --masserase option

### DIFF
--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -249,8 +249,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
             else if (_chipType == "esp32s3")
             {
-                // Assuming S3 has PSRAM.
-                // TODO: [esptool 4.8] The download mode resister is not cleared so a reset/run command does not work on the S3. When esptool 4.8 is released we should retest this to confirm the issue is resovled.
+                // For now assuming all S3 have PSRAM.
+                // TODO: following https://github.com/espressif/esptool/issues/970
+		// The download mode register is not cleared so a reset/run command does not work on the S3. We should retest this after depending on what will be the fix for that issue.
                 psramIsAvailable = PSRamAvailability.Undetermined;
             }
             else

--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -247,12 +247,15 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 // these series doesn't have PSRAM
                 psramIsAvailable = PSRamAvailability.No;
             }
+            else if (_chipType == "esp32s3")
+            {
+                // Assuming S3 has PSRAM
+                psramIsAvailable = PSRamAvailability.Undetermined;
+            }
             else
             {
                 //try to find out if PSRAM is present
-                psramIsAvailable = FindPSRamAvailable(
-                    out psRamSize,
-                    forcePsRamCheck);
+                psramIsAvailable = FindPSRamAvailable(out psRamSize, forcePsRamCheck);
             }
 
             if (Verbosity >= VerbosityLevel.Normal)

--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -249,7 +249,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
             else if (_chipType == "esp32s3")
             {
-                // Assuming S3 has PSRAM
+                // Assuming S3 has PSRAM.
+                // TODO: [esptool 4.8] The download mode resister is not cleared so a reset/run command does not work on the S3. When esptool 4.8 is released we should retest this to confirm the issue is resovled.
                 psramIsAvailable = PSRamAvailability.Undetermined;
             }
             else


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Skip PSRAM detection for ESP32 S3 devices.

## Motivation and Context
- The `--masserase` option is currently broken by this check since the S3 will not exit download mode from a reset/run command
- Possibly related with https://github.com/espressif/esptool#970.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Manually.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [X] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [X] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [X] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [X] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
