### PR TITLE
Fix relative path file for bin files in JLink

### DIFF
--- a/nanoFirmwareFlasher.Library/JLinkCli.cs
+++ b/nanoFirmwareFlasher.Library/JLinkCli.cs
@@ -136,10 +136,13 @@ Exit
             IList<string> addresses,
             string probeId)
         {
-            // check file existence
-            if (files.Any(f => !File.Exists(f)))
+            List<string> shadowFiles = [];
+
+            var processFileResult = ProcessFilePaths(files, shadowFiles);
+
+            if (processFileResult != ExitCodes.OK)
             {
-                return ExitCodes.E5004;
+                return processFileResult;
             }
 
             // perform check on address(es)
@@ -178,10 +181,6 @@ Exit
                     return ExitCodes.E5008;
                 }
             }
-
-            List<string> shadowFiles = [];
-
-            ProcessFilePaths(files, shadowFiles);
 
             // erase flash
             if (DoMassErase)
@@ -284,7 +283,7 @@ Exit
             return ExitCodes.OK;
         }
 
-        private void ProcessFilePaths(IList<string> files, List<string> shadowFiles)
+        private ExitCodes ProcessFilePaths(IList<string> files, List<string> shadowFiles)
         {
             // J-Link can't handle diacritc chars
             // developer note: reported to Segger (Case: 60276735) and can be removed if this is fixed/improved
@@ -294,6 +293,12 @@ Exit
                 var binFilePath = Utilities.MakePathAbsolute(
                     Environment.CurrentDirectory,
                     binFile);
+
+                // check file existence
+                if (!File.Exists(binFilePath))
+                {
+                    return ExitCodes.E5004;
+                }
 
                 if (!binFilePath.IsNormalized(NormalizationForm.FormD)
                     || binFilePath.Contains(' '))
@@ -315,8 +320,9 @@ Exit
                     // copy file to shadow list
                     shadowFiles.Add(binFile);
                 }
-
             }
+
+            return ExitCodes.OK;
         }
 
         /// <summary>
@@ -329,15 +335,14 @@ Exit
             IList<string> files,
             string probeId)
         {
-            // check file existence
-            if (files.Any(f => !File.Exists(f)))
-            {
-                return ExitCodes.E5004;
-            }
-
             List<string> shadowFiles = [];
 
-            ProcessFilePaths(files, shadowFiles);
+            var processFileResult = ProcessFilePaths(files, shadowFiles);
+
+            if (processFileResult != ExitCodes.OK)
+            {
+                return processFileResult;
+            }
 
             // erase flash
             if (DoMassErase)


### PR DESCRIPTION
## Description
- Replace cold check of file existence with parse and test.
- ProcessFilePaths now also checks for file existence.
- Update callers accordingly.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
