### PR TITLE
Improvements in JLink operations

### DIFF
--- a/nanoFirmwareFlasher.Library/JLinkCli.cs
+++ b/nanoFirmwareFlasher.Library/JLinkCli.cs
@@ -280,46 +280,17 @@ Exit
 
             Console.ForegroundColor = ConsoleColor.White;
 
-            return ExitCodes.OK;
-        }
-
-        private ExitCodes ProcessFilePaths(IList<string> files, List<string> shadowFiles)
-        {
-            // J-Link can't handle diacritc chars
-            // developer note: reported to Segger (Case: 60276735) and can be removed if this is fixed/improved
-            foreach (string binFile in files)
+            // be nice and clean up shadow files
+            try
             {
-                // make sure path is absolute
-                var binFilePath = Utilities.MakePathAbsolute(
-                    Environment.CurrentDirectory,
-                    binFile);
-
-                // check file existence
-                if (!File.Exists(binFilePath))
+                foreach (string shadowFile in shadowFiles)
                 {
-                    return ExitCodes.E5004;
+                    File.Delete(shadowFile);
                 }
-
-                if (!binFilePath.IsNormalized(NormalizationForm.FormD)
-                    || binFilePath.Contains(' '))
-                {
-                    var tempFile = Path.Combine(
-                        Environment.GetEnvironmentVariable("TEMP", EnvironmentVariableTarget.Machine),
-                        Path.GetFileName(binFilePath));
-
-                    // copy file to shadow file
-                    File.Copy(
-                        binFilePath,
-                        tempFile,
-                        true);
-
-                    shadowFiles.Add(tempFile);
-                }
-                else
-                {
-                    // copy file to shadow list
-                    shadowFiles.Add(binFile);
-                }
+            }
+            catch (Exception)
+            {
+                // ignore any exception here
             }
 
             return ExitCodes.OK;
@@ -450,10 +421,23 @@ Exit
 
             Console.ForegroundColor = ConsoleColor.White;
 
+            // be nice and clean up shadow files
+            try
+            {
+                foreach (string shadowFile in shadowFiles)
+                {
+                    File.Delete(shadowFile);
+                }
+            }
+            catch (Exception)
+            {
+                // ignore any exception here
+            }
+
             return ExitCodes.OK;
         }
 
-        public void ShowCLIOutput(string cliOutput)
+        internal void ShowCLIOutput(string cliOutput)
         {
             // show CLI output, if verbosity is diagnostic
             if (Verbosity == VerbosityLevel.Diagnostic)
@@ -535,6 +519,48 @@ Exit
             jlinkCli.WaitForExit((int)TimeSpan.FromSeconds(30).TotalMilliseconds);
 
             return jlinkCli.StandardOutput.ReadToEnd();
+        }
+
+        private ExitCodes ProcessFilePaths(IList<string> files, List<string> shadowFiles)
+        {
+            // J-Link can't handle diacritc chars
+            // developer note: reported to Segger (Case: 60276735) and can be removed if this is fixed/improved
+            foreach (string binFile in files)
+            {
+                // make sure path is absolute
+                var binFilePath = Utilities.MakePathAbsolute(
+                    Environment.CurrentDirectory,
+                    binFile);
+
+                // check file existence
+                if (!File.Exists(binFilePath))
+                {
+                    return ExitCodes.E5004;
+                }
+
+                if (!binFilePath.IsNormalized(NormalizationForm.FormD)
+                    || binFilePath.Contains(' '))
+                {
+                    var tempFile = Path.Combine(
+                        Environment.GetEnvironmentVariable("TEMP", EnvironmentVariableTarget.Machine),
+                        Path.GetFileName(binFilePath));
+
+                    // copy file to shadow file
+                    File.Copy(
+                        binFilePath,
+                        tempFile,
+                        true);
+
+                    shadowFiles.Add(tempFile);
+                }
+                else
+                {
+                    // copy file to shadow list
+                    shadowFiles.Add(binFilePath);
+                }
+            }
+
+            return ExitCodes.OK;
         }
     }
 }


### PR DESCRIPTION
## Description
- JLink operations now clean-up files.
- Move private methods to end of file.
- Fix visibility of ShowCLIOutput.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
