### PR TITLE
JLink operations don't delete files anymore

### DIFF
--- a/nanoFirmwareFlasher.Library/JLinkCli.cs
+++ b/nanoFirmwareFlasher.Library/JLinkCli.cs
@@ -138,7 +138,9 @@ Exit
         {
             List<string> shadowFiles = [];
 
-            var processFileResult = ProcessFilePaths(files, shadowFiles);
+            var processFileResult = ProcessFilePaths(
+                files,
+                shadowFiles);
 
             if (processFileResult != ExitCodes.OK)
             {
@@ -280,19 +282,6 @@ Exit
 
             Console.ForegroundColor = ConsoleColor.White;
 
-            // be nice and clean up shadow files
-            try
-            {
-                foreach (string shadowFile in shadowFiles)
-                {
-                    File.Delete(shadowFile);
-                }
-            }
-            catch (Exception)
-            {
-                // ignore any exception here
-            }
-
             return ExitCodes.OK;
         }
 
@@ -308,7 +297,9 @@ Exit
         {
             List<string> shadowFiles = [];
 
-            var processFileResult = ProcessFilePaths(files, shadowFiles);
+            var processFileResult = ProcessFilePaths(
+                files,
+                shadowFiles);
 
             if (processFileResult != ExitCodes.OK)
             {
@@ -421,19 +412,6 @@ Exit
 
             Console.ForegroundColor = ConsoleColor.White;
 
-            // be nice and clean up shadow files
-            try
-            {
-                foreach (string shadowFile in shadowFiles)
-                {
-                    File.Delete(shadowFile);
-                }
-            }
-            catch (Exception)
-            {
-                // ignore any exception here
-            }
-
             return ExitCodes.OK;
         }
 
@@ -521,7 +499,9 @@ Exit
             return jlinkCli.StandardOutput.ReadToEnd();
         }
 
-        private ExitCodes ProcessFilePaths(IList<string> files, List<string> shadowFiles)
+        private static ExitCodes ProcessFilePaths(
+            IList<string> files,
+            List<string> shadowFiles)
         {
             // J-Link can't handle diacritc chars
             // developer note: reported to Segger (Case: 60276735) and can be removed if this is fixed/improved


### PR DESCRIPTION
## Description
- Remove deletion of files programmed after operation completes.
- ProcessFilePaths is now static.

## Motivation and Context
- Binary files were wrongly being deleted after Jlink operation because they weren't copied to temp files. 
- When temp files are created to shadow content of the original ones, it would be nice to delete them. The downside is that the extra processing to handle the situation when these are created (or not) considering the execution path is not worth the trouble. Therefore, we're just letting them there and they can safely be deleted at anytime.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
