### PR TITLE
EditorConfig file added and documented

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,7 @@ spelling_exclusion_path = spelling_exclusion.dic
 
 #=====================================================
 #
-# Formatting rules for C#
+# C# code files
 #
 #=====================================================
 [*.cs]
@@ -74,18 +74,3 @@ csharp_space_between_square_brackets = false
 
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
-
-# Naming rules
-
-# nF_InternalPrivateFields: all private or internal fields
-dotnet_naming_symbols.nF_InternalPrivateFields.applicable_kinds = field
-dotnet_naming_symbols.nF_InternalPrivateFields.applicable_accessibilities = internal, private
-
-# nF_CamelCaseAndUnderscore: camel casing rule
-dotnet_naming_style.nF_CamelCase.capitalization = camel_case
-dotnet_naming_style.nF_CamelCase.required_prefix = _
-
-# nF naming rule for private or internal fields
-dotnet_naming_rule.nF_InternalPrivateFields_Rule.symbols = nF_InternalPrivateFields
-dotnet_naming_rule.nF_InternalPrivateFields_Rule.style = nF_CamelCaseAndUnderscore
-dotnet_naming_rule.nF_InternalPrivateFields_Rule.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,91 @@
+# EditorConfig for Visual Studio 2022: https://learn.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options?view=vs-2022
+
+# This is a top-most .editorconfig file
+root = true
+
+#=====================================================
+#
+# Settings for all file types
+#
+#=====================================================
+[*]
+
+# Generic EditorConfig settings
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+charset = utf-8-bom
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Visual Studio spell checker
+spelling_languages = en-us
+spelling_checkable_types = strings,identifiers,comments
+spelling_error_severity = hint
+spelling_exclusion_path = spelling_exclusion.dic
+
+#=====================================================
+#
+# Formatting rules for C#
+#
+#=====================================================
+[*.cs]
+dotnet_sort_system_directives_first = false
+dotnet_separate_import_directive_groups = false
+
+# Formatting rules
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = true
+
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true
+
+# Naming rules
+
+# nF_InternalPrivateFields: all private or internal fields
+dotnet_naming_symbols.nF_InternalPrivateFields.applicable_kinds = field
+dotnet_naming_symbols.nF_InternalPrivateFields.applicable_accessibilities = internal, private
+
+# nF_CamelCaseAndUnderscore: camel casing rule
+dotnet_naming_style.nF_CamelCase.capitalization = camel_case
+dotnet_naming_style.nF_CamelCase.required_prefix = _
+
+# nF naming rule for private or internal fields
+dotnet_naming_rule.nF_InternalPrivateFields_Rule.symbols = nF_InternalPrivateFields
+dotnet_naming_rule.nF_InternalPrivateFields_Rule.style = nF_CamelCaseAndUnderscore
+dotnet_naming_rule.nF_InternalPrivateFields_Rule.severity = warning


### PR DESCRIPTION
## Description
Added a first version of an .editorconfig file. Another pull request will be made for the documentation repository.

## Motivation and Context
Apparently the nanoFramework uses an appalling coding style as it is different from mine :-) The documentation describes that there is a vssettings file that contains the coding style. As a potential contributor I'm not prepared to modify the Visual Studio settings and to turn off automatic formatting. Fortunately there is a much better way to share these settings, at least for C# - Visual Studio supports adding the settings to an [EditorConfig](https://learn.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options?view=vs-2022) file. 

It is possible to [generate](https://learn.microsoft.com/en-us/visualstudio/ide/code-styles-and-code-cleanup?view=vs-2022#code-styles-in-editorconfig-files) an EditorConfig file from the Visual Studio settings. As I don't have the correct settings, I've just added some of the formatting and naming rules. If I start contributing to the nanoFramework code, an EditorConfig file will also be added if it is not already present.

Perhaps one of the team members could generate a more complete version and add it to the repositories and documentation?

## How Has This Been Tested?
Auto-formatted some of the source files and that did not change the file content.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
