### PR TITLE
Improve output of ESP32 operations

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Operations.cs
@@ -520,7 +520,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                         if (verbosity >= VerbosityLevel.Normal)
                         {
                             OutputWriter.ForegroundColor = ConsoleColor.White;
-                            OutputWriter.Write($"Backup configuration...");
+                            OutputWriter.WriteLine($"Backup configuration...");
                         }
 
                         // can't do this without a partition table
@@ -550,6 +550,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                         if (verbosity >= VerbosityLevel.Normal)
                         {
+                            // move cursor up and clear line
+                            OutputWriter.Write("\u001b[A\r\u001b[K");
+
                             OutputWriter.ForegroundColor = ConsoleColor.White;
                             OutputWriter.Write($"Backup configuration...");
                             OutputWriter.ForegroundColor = ConsoleColor.Green;
@@ -562,12 +565,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                 OutputWriter.ForegroundColor = ConsoleColor.White;
 
-                if (verbosity < VerbosityLevel.Normal)
+                if (verbosity >= VerbosityLevel.Normal)
                 {
-                    // output the start of operation message for verbosity lower than normal
+                    // output the start of operation message for verbosity normal and above
                     // otherwise the progress from esptool is shown
                     OutputWriter.ForegroundColor = ConsoleColor.White;
-                    OutputWriter.Write($"Flashing firmware...");
+                    OutputWriter.WriteLine($"Flashing firmware...");
                 }
 
                 // write to flash
@@ -575,15 +578,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
                 if (operationResult == ExitCodes.OK)
                 {
-                    if (verbosity < VerbosityLevel.Normal)
-                    {
-                        // operation completed output
-                        OutputWriter.ForegroundColor = ConsoleColor.Green;
-                        OutputWriter.WriteLine("OK".PadRight(110));
-                    }
-
                     if (verbosity >= VerbosityLevel.Normal)
                     {
+                        // output the start of operation message for verbosity normal and above
+                        // move cursor up and clear line
+                        OutputWriter.Write("\u001b[A\r\u001b[K");
+
+                        // operation completed output
                         // output the full message as usual after the progress from esptool
                         OutputWriter.ForegroundColor = ConsoleColor.White;
                         OutputWriter.Write($"Flashing firmware...");


### PR DESCRIPTION
## Description
- Output of beginning and completion of operations is not overwritten by esptool progress.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
