### PR TITLE
PSRAM availability for ESP32S3 is now properly shown

### DIFF
--- a/nanoFirmwareFlasher.Library/EspTool.cs
+++ b/nanoFirmwareFlasher.Library/EspTool.cs
@@ -249,10 +249,21 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
             else if (_chipType == "esp32s3")
             {
-                // For now assuming all S3 have PSRAM.
-                // TODO: following https://github.com/espressif/esptool/issues/970
-		// The download mode register is not cleared so a reset/run command does not work on the S3. We should retest this after depending on what will be the fix for that issue.
-                psramIsAvailable = PSRamAvailability.Undetermined;
+                // check device features for PSRAM mention and size
+                // features should look like this: "Features WiFi, BLE, Embedded PSRAM 8MB (AP_3v3)"
+
+                Regex regex = new(@"Embedded PSRAM (?<size>\d+)MB");
+
+                Match psRamMatch = regex.Match(features);
+                if (psRamMatch.Success)
+                {
+                    psRamSize = int.Parse(psRamMatch.Groups["size"].Value);
+                    psramIsAvailable = PSRamAvailability.Yes;
+                }
+                else
+                {
+                    psramIsAvailable = PSRamAvailability.No;
+                }
             }
             else
             {


### PR DESCRIPTION
## Description
- Add parsing of device features to extract this information.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
