### PR TITLE
Add option to skip backup of ESP32 configuration partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ This example uses the binary format file that you can find when you are building
 nanoff --target ESP32_PSRAM_REV0 --update --serialport COM31 --deploy --image "c:\eps32-backups\my_awesome_app.bin" --address 0x1B000
 ```
 
+### Skip backing up configuration partition
+
+To skip backing up the configuration partition when updating the firmware of an ESP32 target connected to COM31.
+```console
+nanoff --update --target ESP32_PSRAM_REV0 --serialport COM31 --noconfigbackup
+```
+
 ## STM32 usage examples
 
 ### Update the firmware of a specific STM32 target

--- a/nanoFirmwareFlasher.Library/Esp32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Operations.cs
@@ -107,6 +107,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="massErase">If <see langword="true"/> perform mass erase on device before updating.</param>
         /// <param name="verbosity">Set verbosity level of progress and error messages.</param>
         /// <param name="partitionTableSize">Size of partition table.</param>
+        /// <param name="noBackupConfig"><see langword="true"/> for skiping backup of configuration partition.</param>
         /// <returns>The <see cref="ExitCodes"/> with the operation result.</returns>
         public static async System.Threading.Tasks.Task<ExitCodes> UpdateFirmwareAsync(
             EspTool espTool,
@@ -123,7 +124,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
             bool fitCheck,
             bool massErase,
             VerbosityLevel verbosity,
-            PartitionTableSize? partitionTableSize)
+            PartitionTableSize? partitionTableSize,
+            bool noBackupConfig)
         {
             ExitCodes operationResult = ExitCodes.OK;
             uint address = 0;
@@ -511,8 +513,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 int configPartitionSize = 0;
                 string configPartitionBackup = Path.GetRandomFileName();
 
-                // if mass erase wasn't requested, backup config partitition
-                if (!massErase)
+                // if mass erase wasn't requested or skip backup config partitition
+                if (!massErase || !noBackupConfig)
                 {
                     // check if the update file includes a partition table
                     if (File.Exists(Path.Combine(firmware.LocationPath, $"partitions_nanoclr_{Esp32DeviceInfo.GetFlashSizeAsString(esp32Device.FlashSize).ToLowerInvariant()}.csv")))

--- a/nanoFirmwareFlasher.Tool/Esp32Manager.cs
+++ b/nanoFirmwareFlasher.Tool/Esp32Manager.cs
@@ -172,7 +172,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     !_options.FitCheck,
                     _options.MassErase,
                     _verbosityLevel,
-                    _options.Esp32PartitionTableSize);
+                    _options.Esp32PartitionTableSize,
+                    _options.NoBackupConfig);
 
                 if (exitCode != ExitCodes.OK || _options.IdentifyFirmware)
                 {

--- a/nanoFirmwareFlasher.Tool/Options.cs
+++ b/nanoFirmwareFlasher.Tool/Options.cs
@@ -138,6 +138,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
             HelpText = "Perform check for PSRAM in device.")]
         public bool CheckPsRam { get; set; }
 
+        [Option(
+            "noconfigbackup",
+            Required = false,
+            Default = false,
+            HelpText = "Skip backup of configuration partition.")]
+        public bool NoBackupConfig { get; set; }
+
         #endregion
 
 

--- a/nanoFirmwareFlasher.sln
+++ b/nanoFirmwareFlasher.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9FD8C426-A16A-49DB-952D-747C3AD96C42}"
 	ProjectSection(SolutionItems) = preProject
 		NuGet.Config = NuGet.Config
+		README.md = README.md
 		version.json = version.json
 	EndProjectSection
 EndProject
@@ -66,7 +67,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		        SolutionGuid = {56E99FF7-1E34-4FB8-8E3C-F98890E741D0}
 		SolutionGuid = {AF6C2B32-984F-41C2-B0F7-B895E45A1BB5}
+		        SolutionGuid = {56E99FF7-1E34-4FB8-8E3C-F98890E741D0}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Description
- Add option to tool.
- Now processing option.
- Update readme with this.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
