### PR TITLE
Add support for 32MB and 64Mb flashing and Esp32-P4 support

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Firmware.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Firmware.cs
@@ -19,9 +19,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
         public const int CLRAddress = 0x10000;
 
         /// <summary>
-        /// ESP32 nanoCLR is available for 2MB, 4MB, 8MB and 16MB flash sizes
+        /// ESP32 nanoCLR is available for 2MB, 4MB, 8MB, 16MB, 32MB and 64MB flash sizes if supported.
         /// </summary>
-        private List<int> SupportedFlashSizes => [0x200000, 0x400000, 0x800000, 0x1000000];
+        private List<int> SupportedFlashSizes => [0x200000, 0x400000, 0x800000, 0x1000000, 0x2000000, 0x4000000];
 
         internal string BootloaderPath;
 
@@ -76,15 +76,26 @@ namespace nanoFramework.Tools.FirmwareFlasher
             {
                 BootloaderPath = "bootloader.bin";
 
+                // Boot loader goes to 0x1000, except for ESP32_C3/C6/H2/S3, which goes to 0x0
+                // and ESP32_P4 where it goes at 0x2000
+                int BootLoaderAddress = 0x1000;
+                if (deviceInfo.ChipType == "ESP32-C3"
+                    || deviceInfo.ChipType == "ESP32-C6"
+                    || deviceInfo.ChipType == "ESP32-H2"
+                    || deviceInfo.ChipType == "ESP32-S3")
+                {
+                    BootLoaderAddress = 0;
+                }
+                if (deviceInfo.ChipType == "ESP32-P4")
+                {
+                    BootLoaderAddress = 0x2000;
+                }
+                
                 // get ESP32 partitions
                 FlashPartitions = new Dictionary<int, string>
                 {
-				    // bootloader goes to 0x1000, except for ESP32_C3/C6/H2/S3, which goes to 0x0
-				    {
-                        deviceInfo.ChipType == "ESP32-C3"
-                        || deviceInfo.ChipType == "ESP32-C6"
-                        || deviceInfo.ChipType == "ESP32-H2"
-                        || deviceInfo.ChipType == "ESP32-S3" ? 0x0 : 0x1000, Path.Combine(LocationPath, BootloaderPath) },
+                    // BootLoader goes to an address depending on chip type
+				    { BootLoaderAddress, Path.Combine(LocationPath, BootloaderPath) },
 
 				    // nanoCLR goes to 0x10000
 				    { CLRAddress, Path.Combine(LocationPath, "nanoCLR.bin") },


### PR DESCRIPTION
## Description
Although change had been done to produce a 32MB partition table, nanoff hadn't been updated to support it

Also opportunity to add support for ESP32_P4 which is in development.
64MB flash and different bootloader address.

## Motivation and Context
- Fixes nanoFramework/Home#1343

- 
## How Has This Been Tested?<!-- (IF APPLICABLE) -->
Locally on 16MB S3 but forcing to 32MB


## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
