### PR TITLE
Firmware archive: bug fix + addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,11 @@ By default, _nanoff_ uses the online repository to look for firmware packages. I
 nanoff --updatearchive --target ESP32_S3_ALL --archivepath c:\...\firmware 
 nanoff --updatearchive --platform esp32 --archivepath c:\...\firmware
 ```
+By default only the most recent firmware version is kept in the archive. If _--platform_ is specified, firmware is removed for targets that are no longer present in the online repository. If old firmware versions should not be deleted from the archive, specify the _--keepallversions_ option:
+```console
+nanoff --updatearchive --target ESP32_S3_ALL --keepallversions --archivepath c:\...\firmware 
+nanoff --updatearchive --platform esp32 --keepallversions --archivepath c:\...\firmware
+```
 
 For a list of archived firmware:
 

--- a/nanoFirmwareFlasher.Library/ExitCodes.cs
+++ b/nanoFirmwareFlasher.Library/ExitCodes.cs
@@ -339,7 +339,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <summary>
         /// Error clearing cache location.
         /// </summary>
-        [Display(Name = "Error occured when clearing the firmware cache location.")]
+        [Display(Name = "Error occurred when clearing the firmware cache location.")]
         E9014 = 9014,
+
+        /// <summary>
+        /// Can't find the target in the firmware archive.
+        /// </summary>
+        [Display(Name = "Can't find the target in the firmware archive.")]
+        E9015 = 9015,
     }
 }

--- a/nanoFirmwareFlasher.Library/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher.Library/FirmwarePackage.cs
@@ -344,6 +344,18 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             }
 
+            if (archiveDirectoryPath is not null && Version is null)
+            {
+                // Find the latest version in the archive directory
+                var archiveManager = new FirmwareArchiveManager(archiveDirectoryPath);
+                Version = archiveManager.GetLatestVersion(_preview, _targetName)?.Version;
+                if (Version is null)
+                {
+                    // Package is considered to be not present, even if it does exist in the cache location
+                    return (ExitCodes.E9015, null);
+                }
+            }
+
             // create the download folder
             try
             {
@@ -369,7 +381,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 if (!File.Exists(archiveFileName))
                 {
                     // Package is considered to be not present, even if it does exist in the cache location
-                    return (ExitCodes.E9007, null);
+                    return (ExitCodes.E9015, null);
                 }
 
                 if (!skipDownload)

--- a/nanoFirmwareFlasher.Tests/FirmwareArchiveManagerTests.cs
+++ b/nanoFirmwareFlasher.Tests/FirmwareArchiveManagerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -34,31 +35,71 @@ namespace nanoFirmwareFlasher.Tests
 
         [TestMethod]
         [TestCategory("CloudSmith")]
-        [DataRow(true)]
-        [DataRow(false)]
-        public void FirmwareArchiveManager_SinglePackage(bool isReferenceTarget)
+        [DataRow(true, true)]
+        [DataRow(true, false)]
+        [DataRow(false, true)]
+        [DataRow(false, false)]
+        public void FirmwareArchiveManager_SinglePackage(bool isReferenceTarget, bool keepAllVersions)
         {
             #region Setup
             using var output = new OutputWriterHelper();
             string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
             string archiveDirectory = Path.Combine(testDirectory, "archive");
-            CloudSmithPackageDetail package = GetTargetListHelper.GetTargetList(!isReferenceTarget, false, SupportedPlatform.esp32)[0];
+            Directory.CreateDirectory(archiveDirectory);
+            Dictionary<string, List<CloudSmithPackageDetail>> packages = GetTargetListHelper.GetTargetList(!isReferenceTarget, false, SupportedPlatform.esp32, false)
+                                                                            .GroupBy(p => p.Name)
+                                                                            .ToDictionary(g => g.Key, g => g.ToList());
+            CloudSmithPackageDetail? packageOldVersion = null;
+            CloudSmithPackageDetail? packageLatestVersion = null;
+            foreach (List<CloudSmithPackageDetail> packageList in packages.Values)
+            {
+                if (packageList.Count > 1)
+                {
+                    Version? latest = null;
+                    foreach (CloudSmithPackageDetail p in packageList)
+                    {
+                        var version = Version.Parse(p.Version);
+                        if (packageLatestVersion is null || version > latest)
+                        {
+                            packageOldVersion = packageLatestVersion ?? p;
+                            packageLatestVersion = p;
+                            latest = version;
+                        }
+                        else
+                        {
+                            packageOldVersion = p;
+                        }
+                    }
+                }
+            }
+            if (packageLatestVersion is null || packageOldVersion is null)
+            {
+                Assert.Inconclusive("No target found in CloudSmith with two firmware versions");
+            }
+
+            // Other target should not be deleted, even if keepAllVersions = false
+            string otherTarget = "OTHER_TARGET";
+            string otherTargetVersion = "1.0.0.0";
+            string otherTargetBasePath = Path.Combine(archiveDirectory, $"{otherTarget}-{otherTargetVersion}.zip");
+            File.WriteAllText(otherTargetBasePath, "");
+            File.WriteAllText(otherTargetBasePath + ".json", $@"{{ ""Name"": ""{otherTarget}"", ""Version"": ""{otherTargetVersion}"", ""Platform"": ""{SupportedPlatform.esp32}"" }}");
+
             output.Reset();
             #endregion
 
-            #region Download the package
+            #region Download the old package
             var actual = new FirmwareArchiveManager(archiveDirectory);
 
             // Note that the platform is determined by the logic in the nanoff tool if a target is specified.
-            ExitCodes exitCode = actual.DownloadFirmwareFromRepository(false, SupportedPlatform.esp32, package.Name, package.Version, VerbosityLevel.Detailed)
+            ExitCodes exitCode = actual.DownloadFirmwareFromRepository(false, SupportedPlatform.esp32, packageOldVersion.Name, packageOldVersion.Version, keepAllVersions, VerbosityLevel.Detailed)
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual(ExitCodes.OK, exitCode);
-            Assert.IsTrue(output.Output.Contains($"Added target {package.Name} {package.Version} to the archive"));
+            Assert.IsTrue(output.Output.Contains($"Added target {packageOldVersion.Name} {packageOldVersion.Version} to the archive"));
             #endregion
 
             #region Assert it is present and can be found via GetTargetList
-            Assert.IsTrue(File.Exists(Path.Combine(archiveDirectory, $"{package.Name}-{package.Version}.zip")));
+            Assert.IsTrue(File.Exists(Path.Combine(archiveDirectory, $"{packageOldVersion.Name}-{packageOldVersion.Version}.zip")));
 
             // List of all packages
             output.Reset();
@@ -66,9 +107,10 @@ namespace nanoFirmwareFlasher.Tests
 
             output.AssertAreEqual("");
             Assert.IsNotNull(list);
-            Assert.AreEqual(
-                $"{package.Name} {package.Version}",
-                string.Join("\n", from p in list select $"{p.Name} {p.Version}"));
+            string present = string.Join("\n", from p in list select $"{p.Name} {p.Version}");
+            Assert.IsTrue(present.Contains($"{packageOldVersion.Name} {packageOldVersion.Version}"));
+            Assert.IsFalse(present.Contains($"{packageLatestVersion.Name} {packageLatestVersion.Version}"));
+            Assert.IsTrue(present.Contains($"{otherTarget} {otherTargetVersion}"));
 
             // List of esp32 packages
             output.Reset();
@@ -76,9 +118,10 @@ namespace nanoFirmwareFlasher.Tests
 
             output.AssertAreEqual("");
             Assert.IsNotNull(list);
-            Assert.AreEqual(
-                $"{package.Name} {package.Version}",
-                string.Join("\n", from p in list select $"{p.Name} {p.Version}"));
+            present = string.Join("\n", from p in list select $"{p.Name} {p.Version}");
+            Assert.IsTrue(present.Contains($"{packageOldVersion.Name} {packageOldVersion.Version}"));
+            Assert.IsFalse(present.Contains($"{packageLatestVersion.Name} {packageLatestVersion.Version}"));
+            Assert.IsTrue(present.Contains($"{otherTarget} {otherTargetVersion}"));
 
             // List of stm32 packages - no match
             output.Reset();
@@ -90,23 +133,79 @@ namespace nanoFirmwareFlasher.Tests
                 "",
                 string.Join("\n", from p in list select $"{p.Name} {p.Version}"));
             #endregion
+
+            #region Download the latest version of the package (without specifying version number)
+            output.Reset();
+            actual = new FirmwareArchiveManager(archiveDirectory);
+
+            // Note that the platform is determined by the logic in the nanoff tool if a target is specified.
+            exitCode = actual.DownloadFirmwareFromRepository(false, SupportedPlatform.esp32, packageLatestVersion.Name, null, keepAllVersions, VerbosityLevel.Detailed)
+                .GetAwaiter().GetResult();
+
+            Assert.AreEqual(ExitCodes.OK, exitCode);
+            Assert.IsTrue(output.Output.Contains($"Added target {packageLatestVersion.Name} {packageLatestVersion.Version} to the archive"));
+            #endregion
+
+            #region Assert the latest version is present, and the old version is present only for keepAllVersions = true
+            Assert.IsTrue(File.Exists(Path.Combine(archiveDirectory, $"{packageLatestVersion.Name}-{packageLatestVersion.Version}.zip")));
+            Assert.AreEqual(keepAllVersions, File.Exists(Path.Combine(archiveDirectory, $"{packageOldVersion.Name}-{packageOldVersion.Version}.zip")));
+
+            // List of all packages
+            output.Reset();
+            list = actual.GetTargetList(false, null, VerbosityLevel.Quiet);
+
+            output.AssertAreEqual("");
+            Assert.IsNotNull(list);
+            present = string.Join("\n", from p in list select $"{p.Name} {p.Version}");
+            Assert.IsTrue(present.Contains($"{packageLatestVersion.Name} {packageLatestVersion.Version}"), "New version");
+            Assert.AreEqual(keepAllVersions, present.Contains($"{packageOldVersion.Name} {packageOldVersion.Version}"), "Old version");
+            #endregion
         }
 
         [TestMethod]
         [TestCategory("CloudSmith")]
-        public void FirmwareArchiveManager_nanoCLR()
+        [DataRow(true)]
+        [DataRow(false)]
+        public void FirmwareArchiveManager_nanoCLR(bool keepAllVersions)
         {
             #region Setup
             using var output = new OutputWriterHelper();
             string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
             string archiveDirectory = Path.Combine(testDirectory, "archive");
             string targetName = "WIN_DLL_nanoCLR";
+            List<CloudSmithPackageDetail> packages = (from p in GetTargetListHelper.GetTargetList(false, false, null, false)
+                                                      where p.Name == targetName
+                                                      select p).ToList();
+            CloudSmithPackageDetail? packageOldVersion = null;
+            CloudSmithPackageDetail? packageLatestVersion = null;
+            if (packages.Count > 1)
+            {
+                Version? latest = null;
+                foreach (CloudSmithPackageDetail p in packages)
+                {
+                    var version = Version.Parse(p.Version);
+                    if (packageLatestVersion is null || version > latest)
+                    {
+                        packageOldVersion = packageLatestVersion ?? p;
+                        packageLatestVersion = p;
+                        latest = version;
+                    }
+                    else
+                    {
+                        packageOldVersion = p;
+                    }
+                }
+            }
+            if (packageLatestVersion is null || packageOldVersion is null)
+            {
+                Assert.Inconclusive("CloudSmith does not have two firmware versions");
+            }
             #endregion
 
-            #region Download the package
+            #region Download the old version of the package
             var actual = new FirmwareArchiveManager(archiveDirectory);
 
-            ExitCodes exitCode = actual.DownloadFirmwareFromRepository(false, null, targetName, null, VerbosityLevel.Detailed)
+            ExitCodes exitCode = actual.DownloadFirmwareFromRepository(false, null, targetName, packageOldVersion.Version, keepAllVersions, VerbosityLevel.Detailed)
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual(ExitCodes.OK, exitCode);
@@ -114,89 +213,88 @@ namespace nanoFirmwareFlasher.Tests
             #endregion
 
             #region Assert it is present
-            var targetDirectory = (from d in Directory.EnumerateDirectories(archiveDirectory)
-                                   where Path.GetFileName(d).StartsWith($"{targetName}-")
-                                   select d).FirstOrDefault();
-            Assert.IsNotNull(targetDirectory);
-            Assert.AreEqual(1, Directory.GetDirectories(archiveDirectory).Length);
+            var targetDirectory = Path.Combine(archiveDirectory, $"{targetName}-{packageOldVersion.Version}");
+            Assert.IsTrue(Directory.Exists(targetDirectory));
             Assert.IsTrue(File.Exists(Path.Combine(targetDirectory, "nanoFramework.nanoCLR.dll")));
             Assert.IsTrue(File.Exists($"{targetDirectory}.json"));
-            #endregion
-        }
 
-        [TestMethod]
-        [TestCategory("CloudSmith")]
-        public void FirmwareArchiveManager_TargetLatestVersion()
-        {
-            #region Setup
-            using var output = new OutputWriterHelper();
-            string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
-            string archiveDirectory = Path.Combine(testDirectory, "archive");
-            CloudSmithPackageDetail package = GetTargetListHelper.GetTargetList(false, false, SupportedPlatform.esp32)[0];
-            output.Reset();
-            #endregion
-
-            #region Download the latest package for the target
-            var actual = new FirmwareArchiveManager(archiveDirectory);
-
-            ExitCodes exitCode = actual.DownloadFirmwareFromRepository(false, SupportedPlatform.esp32, package.Name, null, VerbosityLevel.Quiet)
-                .GetAwaiter().GetResult();
-
-            Assert.AreEqual(ExitCodes.OK, exitCode);
-            output.AssertAreEqual("");
-            #endregion
-
-            #region Assert the package can be found via GetTargetList
             // List of all packages
             output.Reset();
             List<CloudSmithPackageDetail> list = actual.GetTargetList(false, null, VerbosityLevel.Quiet);
 
             output.AssertAreEqual("");
             Assert.IsNotNull(list);
-            Assert.AreEqual(
-                $"{package.Name} {package.Version}\n",
-                string.Join("\n", from p in list orderby p.Name, p.Version select $"{p.Name} {p.Version}") + '\n'
-            );
+            string present = string.Join("\n", from p in list select $"{p.Name} {p.Version}");
+            Assert.IsTrue(present.Contains($"{targetName} {packageOldVersion.Version}"));
+            #endregion
 
-            // List of esp32 packages
+            #region Download the latest version of the package
             output.Reset();
-            list = actual.GetTargetList(false, SupportedPlatform.esp32, VerbosityLevel.Quiet);
+            actual = new FirmwareArchiveManager(archiveDirectory);
+
+            exitCode = actual.DownloadFirmwareFromRepository(false, null, targetName, null, keepAllVersions, VerbosityLevel.Detailed)
+                .GetAwaiter().GetResult();
+
+            Assert.AreEqual(ExitCodes.OK, exitCode);
+            Assert.IsTrue(output.Output.Contains($"Added target {targetName} "));
+            #endregion
+
+            #region Assert it is present and the old package is present depending on keepAllVersions
+            targetDirectory = Path.Combine(archiveDirectory, $"{targetName}-{packageLatestVersion.Version}");
+            Assert.IsTrue(Directory.Exists(targetDirectory));
+            Assert.IsTrue(File.Exists(Path.Combine(targetDirectory, "nanoFramework.nanoCLR.dll")));
+            Assert.IsTrue(File.Exists($"{targetDirectory}.json"));
+
+            targetDirectory = Path.Combine(archiveDirectory, $"{targetName}-{packageOldVersion.Version}");
+            Assert.AreEqual(keepAllVersions, Directory.Exists(targetDirectory));
+
+            // List of all packages
+            output.Reset();
+            list = actual.GetTargetList(false, null, VerbosityLevel.Quiet);
 
             output.AssertAreEqual("");
             Assert.IsNotNull(list);
-            Assert.AreEqual(
-                $"{package.Name} {package.Version}\n",
-                string.Join("\n", from p in list orderby p.Name, p.Version select $"{p.Name} {p.Version}") + '\n'
-            );
-
-            // List of stm32 packages - no match
-            output.Reset();
-            list = actual.GetTargetList(false, SupportedPlatform.stm32, VerbosityLevel.Quiet);
-
-            output.AssertAreEqual("");
-            Assert.IsNotNull(list);
-            Assert.AreEqual(
-                "",
-                string.Join("\n", from p in list select $"{p.Name} {p.Version}"));
+            present = string.Join("\n", from p in list select $"{p.Name} {p.Version}");
+            Assert.IsTrue(present.Contains($"{targetName} {packageLatestVersion.Version}"), "New version");
+            Assert.AreEqual(keepAllVersions, present.Contains($"{targetName} {packageOldVersion.Version}"), "Old version");
             #endregion
         }
 
         [TestMethod]
         [TestCategory("CloudSmith")]
-        public void FirmwareArchiveManager_Platform()
+        [DataRow(true)]
+        [DataRow(false)]
+        public void FirmwareArchiveManager_Platform(bool keepAllVersions)
         {
             #region Setup
             using var output = new OutputWriterHelper();
             string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
             string archiveDirectory = Path.Combine(testDirectory, "archive");
-            List<CloudSmithPackageDetail> stablePackages = GetTargetListHelper.GetTargetList(null, false, SupportedPlatform.ti_simplelink);
+            Directory.CreateDirectory(archiveDirectory);
+
+            string targetNoLongerPresent = "NO_LONGER_PRESENT";
+            string targetNoLongerPresentVersion = "1.0.0.0";
+            string targetNoLongerPresentBasePath = Path.Combine(archiveDirectory, $"{targetNoLongerPresent}-{targetNoLongerPresentVersion}.zip");
+            File.WriteAllText(targetNoLongerPresentBasePath, "");
+            File.WriteAllText(targetNoLongerPresentBasePath + ".json", $@"{{ ""Name"": ""{targetNoLongerPresent}"", ""Version"": ""{targetNoLongerPresentVersion}"", ""Platform"": ""{SupportedPlatform.ti_simplelink}"" }}");
+
+            List<CloudSmithPackageDetail> expectedPackages = GetTargetListHelper.GetTargetList(null, false, SupportedPlatform.ti_simplelink);
+            if (keepAllVersions)
+            {
+                expectedPackages.Add(new CloudSmithPackageDetail
+                {
+                    Name = targetNoLongerPresent,
+                    Version = targetNoLongerPresentVersion
+                });
+            }
+
             output.Reset();
             #endregion
 
             #region Download all packages
             var actual = new FirmwareArchiveManager(archiveDirectory);
 
-            ExitCodes exitCode = actual.DownloadFirmwareFromRepository(false, SupportedPlatform.ti_simplelink, null, null, VerbosityLevel.Quiet)
+            ExitCodes exitCode = actual.DownloadFirmwareFromRepository(false, SupportedPlatform.ti_simplelink, null, null, keepAllVersions, VerbosityLevel.Quiet)
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual(ExitCodes.OK, exitCode);
@@ -211,18 +309,18 @@ namespace nanoFirmwareFlasher.Tests
             output.AssertAreEqual("");
             Assert.IsNotNull(list);
             Assert.AreEqual(
-                string.Join("\n", from p in stablePackages orderby p.Name, p.Version select $"{p.Name} {p.Version}") + '\n',
+                string.Join("\n", from p in expectedPackages orderby p.Name, p.Version select $"{p.Name} {p.Version}") + '\n',
                 string.Join("\n", from p in list orderby p.Name, p.Version select $"{p.Name} {p.Version}") + '\n'
             );
 
-            // List of esp32 packages
+            // List of ti_simplelink packages
             output.Reset();
             list = actual.GetTargetList(false, SupportedPlatform.ti_simplelink, VerbosityLevel.Quiet);
 
             output.AssertAreEqual("");
             Assert.IsNotNull(list);
             Assert.AreEqual(
-                string.Join("\n", from p in stablePackages orderby p.Name, p.Version select $"{p.Name} {p.Version}") + '\n',
+                string.Join("\n", from p in expectedPackages orderby p.Name, p.Version select $"{p.Name} {p.Version}") + '\n',
                 string.Join("\n", from p in list orderby p.Name, p.Version select $"{p.Name} {p.Version}") + '\n'
             );
 

--- a/nanoFirmwareFlasher.Tests/ToolFirmwareArchiveTests.cs
+++ b/nanoFirmwareFlasher.Tests/ToolFirmwareArchiveTests.cs
@@ -33,21 +33,21 @@ namespace nanoFirmwareFlasher.Tests
             #endregion
 
             #region List empty archive
-            int actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--fwarchivepath", archiveDirectory])
+            int actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--archivepath", archiveDirectory])
                     .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
             #endregion
 
             #region Update archive
             output.Reset();
-            actual = Program.Main(["--updatefwarchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fwarchivepath", archiveDirectory])
+            actual = Program.Main(["--updatearchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--archivepath", archiveDirectory])
                 .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
             #endregion
 
             #region List filled archive
             output.Reset();
-            actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--fwarchivepath", archiveDirectory])
+            actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--archivepath", archiveDirectory])
                     .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
 
@@ -70,14 +70,14 @@ namespace nanoFirmwareFlasher.Tests
 
             #region Update archive
             output.Reset();
-            int actual = Program.Main(["--updatefwarchive", "--target", $"{allPackages[0].Name}", "--fwarchivepath", archiveDirectory])
+            int actual = Program.Main(["--updatearchive", "--target", $"{allPackages[0].Name}", "--archivepath", archiveDirectory])
                 .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
             #endregion
 
             #region List filled archive
             output.Reset();
-            actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--fwarchivepath", archiveDirectory])
+            actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--archivepath", archiveDirectory])
                     .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
 
@@ -96,11 +96,11 @@ namespace nanoFirmwareFlasher.Tests
             string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
             string archiveDirectory = Path.Combine(testDirectory, "archive");
 
-            int actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--verbosity", "diagnostic"])
+            int actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--fwarchivepath is required when --fromfwarchive is specified."));
+            Assert.IsTrue(output.Output.Contains("--archivepath is required when --fromarchive is specified."));
         }
 
         [TestMethod]
@@ -110,25 +110,32 @@ namespace nanoFirmwareFlasher.Tests
             string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
             string archiveDirectory = Path.Combine(testDirectory, "archive");
 
-            int actual = Program.Main(["--updatefwarchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--verbosity", "diagnostic"])
+            int actual = Program.Main(["--updatearchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("Incompatible option --fromfwarchive combined with --updatefwarchive."));
+            Assert.IsTrue(output.Output.Contains("Incompatible option --fromarchive combined with --updatearchive."));
 
             output.Reset();
-            actual = Program.Main(["--updatefwarchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--verbosity", "diagnostic"])
+            actual = Program.Main(["--updatearchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--fwarchivepath is required when --updatefwarchive is specified."));
+            Assert.IsTrue(output.Output.Contains("--archivepath is required when --updatearchive is specified."));
 
             output.Reset();
-            actual = Program.Main(["--updatefwarchive", "--fwarchivepath", $"{SupportedPlatform.ti_simplelink}", "--verbosity", "diagnostic"])
+            actual = Program.Main(["--updatearchive", "--archivepath", archiveDirectory, "--platform", $"{SupportedPlatform.ti_simplelink}", "--keepallversions"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--platform or --target is required when --updatefwarchive is specified."));
+            Assert.IsTrue(output.Output.Contains("--keepallversions can only be used with --target and not when --platform is specified."));
+
+            output.Reset();
+            actual = Program.Main(["--updatearchive", "--archivepath", $"{SupportedPlatform.ti_simplelink}", "--verbosity", "diagnostic"])
+                .GetAwaiter().GetResult();
+
+            Assert.AreEqual((int)ExitCodes.E9000, actual);
+            Assert.IsTrue(output.Output.Contains("--platform or --target is required when --updatearchive is specified."));
         }
 
         [TestMethod]
@@ -138,18 +145,18 @@ namespace nanoFirmwareFlasher.Tests
             string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
             string archiveDirectory = Path.Combine(testDirectory, "archive");
 
-            int actual = Program.Main(["--serialport", "COM3", "--target", "SOME_TARGET", "--fromfwarchive", "--verbosity", "diagnostic"])
+            int actual = Program.Main(["--serialport", "COM3", "--target", "SOME_TARGET", "--fromarchive", "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--fwarchivepath is required when --fromfwarchive is specified."));
+            Assert.IsTrue(output.Output.Contains("--archivepath is required when --fromarchive is specified."));
 
             output.Reset();
-            actual = Program.Main(["--serialport", "COM3", "--target", "SOME_TARGET", "--fwarchivepath", archiveDirectory, "--verbosity", "diagnostic"])
+            actual = Program.Main(["--serialport", "COM3", "--target", "SOME_TARGET", "--archivepath", archiveDirectory, "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--fromfwarchive is required when --fwarchivepath is specified."));
+            Assert.IsTrue(output.Output.Contains("--fromarchive is required when --archivepath is specified."));
         }
     }
 }

--- a/nanoFirmwareFlasher.Tool/Options.cs
+++ b/nanoFirmwareFlasher.Tool/Options.cs
@@ -375,6 +375,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
         public bool UpdateFwArchive { get; set; }
 
         [Option(
+            "keepallversions",
+            Required = false,
+            Default = false,
+            HelpText = "Keep all firmware versions for the target in the firmware archive.")]
+        public bool KeepAllFwVersions { get; set; }
+
+        [Option(
             "fromarchive",
             Required = false,
             Default = false,

--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -286,7 +286,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     if (string.IsNullOrEmpty(o.FwArchivePath))
                     {
                         _exitCode = ExitCodes.E9000;
-                        _extraMessage = "--fwarchivepath is required when --fromfwarchive is specified.";
+                        _extraMessage = "--archivepath is required when --fromarchive is specified.";
                         return;
                     }
 
@@ -555,20 +555,27 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 if (o.FromFwArchive)
                 {
                     _exitCode = ExitCodes.E9000;
-                    _extraMessage = "Incompatible option --fromfwarchive combined with --updatefwarchive.";
+                    _extraMessage = "Incompatible option --fromarchive combined with --updatearchive.";
                     return;
                 }
                 if (string.IsNullOrEmpty(o.FwArchivePath))
                 {
                     _exitCode = ExitCodes.E9000;
-                    _extraMessage = $"--fwarchivepath is required when --updatefwarchive is specified.";
+                    _extraMessage = $"--archivepath is required when --updatearchive is specified.";
                     return;
                 }
 
                 if (o.Platform is null && string.IsNullOrEmpty(o.TargetName))
                 {
                     _exitCode = ExitCodes.E9000;
-                    _extraMessage = $"--platform or --target is required when --updatefwarchive is specified.";
+                    _extraMessage = $"--platform or --target is required when --updatearchive is specified.";
+                    return;
+                }
+
+                if (o.KeepAllFwVersions && string.IsNullOrEmpty(o.TargetName))
+                {
+                    _exitCode = ExitCodes.E9000;
+                    _extraMessage = $"--keepallversions can only be used with --target and not when --platform is specified.";
                     return;
                 }
 
@@ -578,6 +585,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     o.Platform,
                     o.TargetName,
                     o.FwVersion,
+                    o.KeepAllFwVersions,
                     _verbosityLevel);
                 return;
             }
@@ -588,14 +596,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 if (o.FromFwArchive)
                 {
                     _exitCode = ExitCodes.E9000;
-                    _extraMessage = $"--fwarchivepath is required when --fromfwarchive is specified.";
+                    _extraMessage = $"--archivepath is required when --fromarchive is specified.";
                     return;
                 }
             }
             else if (!o.FromFwArchive)
             {
                 _exitCode = ExitCodes.E9000;
-                _extraMessage = $"--fromfwarchive is required when --fwarchivepath is specified.";
+                _extraMessage = $"--fromarchive is required when --archivepath is specified.";
                 return;
             }
             #endregion


### PR DESCRIPTION
## Description
- Bug: If the firmware of a device is updated from the firmware archive, the firmware version has to be specified. Fix: if no firmware version is specified, the most recent version present in the archive is selected.
- Bug fix (cosmetic): some error messages related to incorrect nanoff argument combinations still used "fwarchive" rather than "archive"; this has been changed.
- Bug fix (cosmetic): if a package is not found in the archive, the exit code was "cannot download package". Changed to: "Can't find the target in the firmware archive."
- Addition: if the firmware archive is updated via nanoff --updatearchive and a new firmware version is downloaded, the old version(s) are deleted. If a target is no longer present in the online archive, the target is removed from the archive. This behavior can be disabled by specifying the (new) --keepallversions option. 
- Unit tests are updated to include the new functionality and to detect the first bug (if it ever resurfaces).

## Motivation and Context
I'm using nanoff to maintain a firmware archive (as part of the support for versioning strategies). I've combined the bug fixes and the extra functionality as both are the result of "nanoff should be improved to make it easier to maintain and use the firmware archive". If you prefer two PRs (one with bug fixes and one with the additional functionality) that is also possible. Then I'll delete this PR and first create one for the bug fixes.

The first bug surfaced when I tried to update the firmware for a new device, as described in the README.md file. I was surprised as there were unit tests that verified the use of firmware from the firmware archive. Unfortunately all tests specified the version of the firmware. So I've updated the unit tests to test both the specification and omission of the firmware version, and fixed the bug when the version was not specified.

While investigating the bug I noticed the use of "fwarchive" in error messages. Not sure how that escaped the change of "fwarchive" to "archive" in the PR that introduced the firmware archive. As this is cosmetic, the updates are included in this PR.

For one set of nanoFramework projects I use the "daily updates" strategy. The projects always use the latest firmware and NuGet packages, the firmware archive is used to verify the presence of native assemblies required by the projects in the firmware of the devices the projects will be deployed to. For this a script is executed daily that updates the firmware archive (if necessary). At first I thought the best way to update the archive is to delete all packages and then download the latest version. But no download is required if the most recent version is already in the archive, so the best approach is to *not* delete all packages in the archive before running the script. But then, after some time, the archive contains a lot of packages. Some targets had of the order of 10 versions in two months. It is not easy to automatically clean up the archive via a script, as that would require implementing some of the same logic to read the archive content as is present in nanoff. So I added the archive cleanup as a default to nanoff, and introduced a new option to prevent archive cleanup in case a user wants to store multiple versions in the archive.

The cleanup functionality is probably a breaking change, but as the first bug has not been discovered so far, I'm probably the only user of that functionality.

## How Has This Been Tested?

The unit tests have been updated to detect the bugs and to test the new functionality.  Also nanoff has been run to update firmware from the archive without firmware version specified, and to update the firmware archive with cleanup.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
