### PR TITLE
Firmware archive related bug fixes

### DIFF
--- a/nanoFirmwareFlasher.Library/ExitCodes.cs
+++ b/nanoFirmwareFlasher.Library/ExitCodes.cs
@@ -339,7 +339,13 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <summary>
         /// Error clearing cache location.
         /// </summary>
-        [Display(Name = "Error occured when clearing the firmware cache location.")]
+        [Display(Name = "Error occurred when clearing the firmware cache location.")]
         E9014 = 9014,
+
+        /// <summary>
+        /// Can't find the target in the firmware archive.
+        /// </summary>
+        [Display(Name = "Can't find the target in the firmware archive.")]
+        E9015 = 9015,
     }
 }

--- a/nanoFirmwareFlasher.Library/FirmwareArchiveManager.cs
+++ b/nanoFirmwareFlasher.Library/FirmwareArchiveManager.cs
@@ -68,6 +68,40 @@ namespace nanoFramework.Tools.FirmwareFlasher
         }
 
         /// <summary>
+        /// Get the latest version present in the firmware archive for the specified target.
+        /// </summary>
+        /// <param name="preview">Option for preview version.</param>
+        /// <param name="target">Target to find the latest version of.</param>
+        /// <returns>The <see cref="CloudSmithPackageDetail"/> with details on latest firmware package for the target, or <see langword="null"/> if none is present.</returns>
+        public CloudSmithPackageDetail GetLatestVersion(
+            bool preview,
+            string target)
+        {
+            CloudSmithPackageDetail result = null;
+            Version latest = null;
+            if (Directory.Exists(_archivePath) && !string.IsNullOrEmpty(target))
+            {
+                foreach (string filePath in Directory.EnumerateFiles(_archivePath, $"{target}-*{INFOFILE_EXTENSION}"))
+                {
+                    PersistedPackageInformation packageInformation = JsonConvert.DeserializeObject<PersistedPackageInformation>(File.ReadAllText(filePath));
+                    if (packageInformation is not null && packageInformation.IsPreview == preview)
+                    {
+                        if (Version.TryParse(packageInformation.Version, out Version version))
+                        {
+                            if (latest is null || latest < version)
+                            {
+                                latest = version;
+                                result = packageInformation;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Download a firmware package from the repository and add it to the archive directory
         /// </summary>
         /// <param name="preview">Option for preview version.</param>

--- a/nanoFirmwareFlasher.Library/FirmwarePackage.cs
+++ b/nanoFirmwareFlasher.Library/FirmwarePackage.cs
@@ -344,6 +344,18 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             }
 
+            if (archiveDirectoryPath is not null && Version is null)
+            {
+                // Find the latest version in the archive directory
+                var archiveManager = new FirmwareArchiveManager(archiveDirectoryPath);
+                Version = archiveManager.GetLatestVersion(_preview, _targetName)?.Version;
+                if (Version is null)
+                {
+                    // Package is considered to be not present, even if it does exist in the cache location
+                    return (ExitCodes.E9015, null);
+                }
+            }
+
             // create the download folder
             try
             {
@@ -369,7 +381,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 if (!File.Exists(archiveFileName))
                 {
                     // Package is considered to be not present, even if it does exist in the cache location
-                    return (ExitCodes.E9007, null);
+                    return (ExitCodes.E9015, null);
                 }
 
                 if (!skipDownload)

--- a/nanoFirmwareFlasher.Tests/ToolFirmwareArchiveTests.cs
+++ b/nanoFirmwareFlasher.Tests/ToolFirmwareArchiveTests.cs
@@ -33,21 +33,21 @@ namespace nanoFirmwareFlasher.Tests
             #endregion
 
             #region List empty archive
-            int actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--fwarchivepath", archiveDirectory])
+            int actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--archivepath", archiveDirectory])
                     .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
             #endregion
 
             #region Update archive
             output.Reset();
-            actual = Program.Main(["--updatefwarchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fwarchivepath", archiveDirectory])
+            actual = Program.Main(["--updatearchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--archivepath", archiveDirectory])
                 .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
             #endregion
 
             #region List filled archive
             output.Reset();
-            actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--fwarchivepath", archiveDirectory])
+            actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--archivepath", archiveDirectory])
                     .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
 
@@ -70,14 +70,14 @@ namespace nanoFirmwareFlasher.Tests
 
             #region Update archive
             output.Reset();
-            int actual = Program.Main(["--updatefwarchive", "--target", $"{allPackages[0].Name}", "--fwarchivepath", archiveDirectory])
+            int actual = Program.Main(["--updatearchive", "--target", $"{allPackages[0].Name}", "--archivepath", archiveDirectory])
                 .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
             #endregion
 
             #region List filled archive
             output.Reset();
-            actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--fwarchivepath", archiveDirectory])
+            actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--archivepath", archiveDirectory])
                     .GetAwaiter().GetResult();
             Assert.AreEqual((int)ExitCodes.OK, actual);
 
@@ -96,11 +96,11 @@ namespace nanoFirmwareFlasher.Tests
             string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
             string archiveDirectory = Path.Combine(testDirectory, "archive");
 
-            int actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--verbosity", "diagnostic"])
+            int actual = Program.Main(["--listtargets", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--fwarchivepath is required when --fromfwarchive is specified."));
+            Assert.IsTrue(output.Output.Contains("--archivepath is required when --fromarchive is specified."));
         }
 
         [TestMethod]
@@ -110,25 +110,25 @@ namespace nanoFirmwareFlasher.Tests
             string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
             string archiveDirectory = Path.Combine(testDirectory, "archive");
 
-            int actual = Program.Main(["--updatefwarchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromfwarchive", "--verbosity", "diagnostic"])
+            int actual = Program.Main(["--updatearchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--fromarchive", "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("Incompatible option --fromfwarchive combined with --updatefwarchive."));
+            Assert.IsTrue(output.Output.Contains("Incompatible option --fromarchive combined with --updatearchive."));
 
             output.Reset();
-            actual = Program.Main(["--updatefwarchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--verbosity", "diagnostic"])
+            actual = Program.Main(["--updatearchive", "--platform", $"{SupportedPlatform.ti_simplelink}", "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--fwarchivepath is required when --updatefwarchive is specified."));
+            Assert.IsTrue(output.Output.Contains("--archivepath is required when --updatearchive is specified."));
 
             output.Reset();
-            actual = Program.Main(["--updatefwarchive", "--fwarchivepath", $"{SupportedPlatform.ti_simplelink}", "--verbosity", "diagnostic"])
+            actual = Program.Main(["--updatearchive", "--archivepath", $"{SupportedPlatform.ti_simplelink}", "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--platform or --target is required when --updatefwarchive is specified."));
+            Assert.IsTrue(output.Output.Contains("--platform or --target is required when --updatearchive is specified."));
         }
 
         [TestMethod]
@@ -138,18 +138,18 @@ namespace nanoFirmwareFlasher.Tests
             string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
             string archiveDirectory = Path.Combine(testDirectory, "archive");
 
-            int actual = Program.Main(["--serialport", "COM3", "--target", "SOME_TARGET", "--fromfwarchive", "--verbosity", "diagnostic"])
+            int actual = Program.Main(["--serialport", "COM3", "--target", "SOME_TARGET", "--fromarchive", "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--fwarchivepath is required when --fromfwarchive is specified."));
+            Assert.IsTrue(output.Output.Contains("--archivepath is required when --fromarchive is specified."));
 
             output.Reset();
-            actual = Program.Main(["--serialport", "COM3", "--target", "SOME_TARGET", "--fwarchivepath", archiveDirectory, "--verbosity", "diagnostic"])
+            actual = Program.Main(["--serialport", "COM3", "--target", "SOME_TARGET", "--archivepath", archiveDirectory, "--verbosity", "diagnostic"])
                 .GetAwaiter().GetResult();
 
             Assert.AreEqual((int)ExitCodes.E9000, actual);
-            Assert.IsTrue(output.Output.Contains("--fromfwarchive is required when --fwarchivepath is specified."));
+            Assert.IsTrue(output.Output.Contains("--fromarchive is required when --archivepath is specified."));
         }
     }
 }

--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -286,7 +286,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     if (string.IsNullOrEmpty(o.FwArchivePath))
                     {
                         _exitCode = ExitCodes.E9000;
-                        _extraMessage = "--fwarchivepath is required when --fromfwarchive is specified.";
+                        _extraMessage = "--archivepath is required when --fromarchive is specified.";
                         return;
                     }
 
@@ -555,20 +555,20 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 if (o.FromFwArchive)
                 {
                     _exitCode = ExitCodes.E9000;
-                    _extraMessage = "Incompatible option --fromfwarchive combined with --updatefwarchive.";
+                    _extraMessage = "Incompatible option --fromarchive combined with --updatearchive.";
                     return;
                 }
                 if (string.IsNullOrEmpty(o.FwArchivePath))
                 {
                     _exitCode = ExitCodes.E9000;
-                    _extraMessage = $"--fwarchivepath is required when --updatefwarchive is specified.";
+                    _extraMessage = $"--archivepath is required when --updatearchive is specified.";
                     return;
                 }
 
                 if (o.Platform is null && string.IsNullOrEmpty(o.TargetName))
                 {
                     _exitCode = ExitCodes.E9000;
-                    _extraMessage = $"--platform or --target is required when --updatefwarchive is specified.";
+                    _extraMessage = $"--platform or --target is required when --updatearchive is specified.";
                     return;
                 }
 
@@ -588,14 +588,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 if (o.FromFwArchive)
                 {
                     _exitCode = ExitCodes.E9000;
-                    _extraMessage = $"--fwarchivepath is required when --fromfwarchive is specified.";
+                    _extraMessage = $"--archivepath is required when --fromarchive is specified.";
                     return;
                 }
             }
             else if (!o.FromFwArchive)
             {
                 _exitCode = ExitCodes.E9000;
-                _extraMessage = $"--fromfwarchive is required when --fwarchivepath is specified.";
+                _extraMessage = $"--fromarchive is required when --archivepath is specified.";
                 return;
             }
             #endregion


### PR DESCRIPTION
## Description

* Bug: If the firmware of a device is updated from the firmware archive, the firmware version has to be specified. Fix: if no firmware version is specified, the most recent version present in the archive is selected.
* Bug fix (cosmetic): some error messages related to incorrect nanoff argument combinations still used "fwarchive" rather than "archive"; this has been changed.
* Bug fix (cosmetic): if a package is not found in the archive, the exit code was "cannot download package". Changed to: "Can't find the target in the firmware archive."
* Unit tests are updated to include to detect the first bug (if it ever resurfaces).

## Motivation and Context

The first bug surfaced when I tried to update the firmware for a new device from the firmware archive, as described in the README.md file. I was surprised as there were unit tests that verified the use of firmware from the firmware archive. Unfortunately all tests specified the version of the firmware. So I've updated the unit tests to test both the specification and omission of the firmware version, and fixed the bug when the version was not specified.

While investigating the bug I noticed the use of "fwarchive" in error messages. Not sure how that escaped the change of "fwarchive" to "archive" in the PR that introduced the firmware archive. As this is cosmetic, the updates are included in this PR.

## How Has This Been Tested?

The unit tests have been updated to detect the bugs. Also nanoff has been run to update firmware from the archive without firmware version specified.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
