### PR TITLE
Hard reset added for several ESP32 options missing it

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Operations.cs
@@ -20,13 +20,15 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="backupPath">Path to store backup image.</param>
         /// <param name="fileName">Name of backup file.</param>
         /// <param name="verbosity">Set verbosity level of progress and error messages.</param>
+        /// <param name="hardResetAfterCommand">if true the chip will execute a hard reset via DTR signal</param>
         /// <returns>The <see cref="ExitCodes"/> with the operation result.</returns>
         public static ExitCodes BackupFlash(
             EspTool tool,
             Esp32DeviceInfo device,
             string backupPath,
             string fileName,
-            VerbosityLevel verbosity)
+            VerbosityLevel verbosity,
+            bool hardResetAfterCommand = false)
         {
             // check for backup file without backup path
             if (!string.IsNullOrEmpty(fileName) &&
@@ -77,7 +79,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 OutputWriter.ForegroundColor = ConsoleColor.White;
             }
 
-            tool.BackupFlash(backupFilePath, device.FlashSize);
+            tool.BackupFlash(backupFilePath, device.FlashSize, hardResetAfterCommand);
 
             if (verbosity > VerbosityLevel.Quiet)
             {

--- a/nanoFirmwareFlasher.Tool/Esp32Manager.cs
+++ b/nanoFirmwareFlasher.Tool/Esp32Manager.cs
@@ -78,6 +78,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 return ExitCodes.E4005;
             }
 
+            bool backupFlash = !string.IsNullOrEmpty(_options.BackupPath) ||
+               !string.IsNullOrEmpty(_options.BackupFile);
+
             Esp32DeviceInfo esp32Device;
 
             if (espTool.ComPortAvailable)
@@ -86,7 +89,9 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     _options.TargetName,
                     // if partition table size is specified, no need to get flash size
                     _options.Esp32PartitionTableSize == null,
-                    _options.CheckPsRam);
+                    _options.CheckPsRam,
+                    (_options.DeviceDetails || _options.IdentifyFirmware) && !backupFlash
+                    );
             }
             else
             {
@@ -131,11 +136,16 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // backup requested
             // Should backup be an unique operation => exit whatever success or not ?
             // In this case, should find how manage a NoOperationPerformedException info
-            if (!string.IsNullOrEmpty(_options.BackupPath) ||
-               !string.IsNullOrEmpty(_options.BackupFile))
+            if (backupFlash)
             {
                 // backup path specified, backup deployment
-                var exitCode = Esp32Operations.BackupFlash(espTool, esp32Device, _options.BackupPath, _options.BackupFile, _verbosityLevel);
+                var exitCode = Esp32Operations.BackupFlash(
+                    espTool,
+                    esp32Device,
+                    _options.BackupPath,
+                    _options.BackupFile,
+                    _verbosityLevel,
+                    _options.DeviceDetails || _options.IdentifyFirmware);
 
                 if (exitCode != ExitCodes.OK)
                 {


### PR DESCRIPTION
## Description

- Added some logic in the Esp32Manager to determine whether the sequence of steps does not result in an update of flash memory, but ends after obtaining information. 
- If that is the case, the last execution of esptool to be executed will hard reset the device.

## Motivation and Context

If a ESP32-platform nanoDevice is running normally, a firmware update via `nanoff --update` ends with a reset of the device. The device boots normally and can be re-discovered by the device explorer / `nanoff --listdevices`.

If the device's flash memory is not updated but the commands `nanoff --devicedetails` and `nanoff --identifyfirmware` (with optional --backuppath / --backupfile options) are run, the device disappears from the device explorer / `nanoff --listdevices`. These commands leave the device in the serial bootloader stage.

The fix is to detect the three options that do not update the device's flash, and make sure that the last interaction with the device asks for a hard reset of the device.

## How Has This Been Tested?

Running nanoff on my PC

## Types of changes
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
