### PR TITLE
Firmware archive: get platform from CloudSmith

### DIFF
--- a/nanoFirmwareFlasher.Library/CloudSmithPackageDetails.cs
+++ b/nanoFirmwareFlasher.Library/CloudSmithPackageDetails.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -20,5 +23,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// Package version.
         /// </summary>
         public string Version { get; set; }
+
+        /// <summary>
+        /// Platform code
+        /// </summary>
+        public string Platform { get; set; }
     }
 }

--- a/nanoFirmwareFlasher.Library/FirmwareArchiveManager.cs
+++ b/nanoFirmwareFlasher.Library/FirmwareArchiveManager.cs
@@ -187,7 +187,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     IsPreview = preview,
                     Name = remoteTarget.Name,
-                    Platform = platform.ToString(),
+                    Platform = remoteTarget.Platform ?? platform?.ToString(),
                     Version = remoteTarget.Version,
                 };
                 File.WriteAllText(
@@ -209,11 +209,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// </summary>
         private sealed class PersistedPackageInformation : CloudSmithPackageDetail
         {
-            /// <summary>
-            /// Platform code
-            /// </summary>
-            public string Platform { get; set; }
-
             /// <summary>
             /// Indicates whether this is a preview
             /// </summary>


### PR DESCRIPTION
## Description

- Extra Platform property in CloudSmithPackageDetail
- Property's value assigned from the tag in the CloudSmith metadata
- Property used when downloading firmware to the firmware archive to store the platform.

## Motivation and Context

Until now the firmware archive manager uses the platform as it is derived by logic in the nanoff program. For some targets (in my case XIAO_ESP32C3) the logic cannot determine the correct platform. As a consequence, `nanoff --listtargets --fromarchive --platform X` will not return the same targets as `nanoff --listtargets --fromarchive --platform X`.

The changes in this PR parse the tags of the CloudSmith  package details and keep the tag that matches one of the SupportedPlatform values.

After the change, the platform is copied correctly to the firmware archive for all targets except SL_STK3701A_REVB
and NXP_MIMXRT1060_EVK, as the tags for those do not include any of the SupportedPlatform values.

## How Has This Been Tested?

- Unit test re-run
- nanoff --listtargets and verified that the Platform was assigned correctly.

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
