### PR TITLE
Fix platform names

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ To update the firmware of a Silabs target with a local firmware file (for exampl
 This file has to be a binary file with a valid Booter and CLR from a build. No checks or validations are performed on the file(s) content.
 
 ```console
-nanoff --update --platform gg11 --binfile "C:\nf-interpreter\build\nanobooter-nanoclr.bin" --address 0x0
+nanoff --update --platform efm32 --binfile "C:\nf-interpreter\build\nanobooter-nanoclr.bin" --address 0x0
 ```
 
 ### Deploy a managed application to a SL_STK3701A target

--- a/nanoFirmwareFlasher.Library/SupportedPlatform.cs
+++ b/nanoFirmwareFlasher.Library/SupportedPlatform.cs
@@ -22,9 +22,15 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// TI Simplelink.
         /// </summary>
         ti_simplelink = 2,
+
         /// <summary>
-        /// Silabs GG11.
+        /// Silabs EFM32 Gecko.
         /// </summary>
-        gg11
+        efm32,
+
+        /// <summary>
+        /// NXP.
+        /// </summary>
+        nxp
     }
 }

--- a/nanoFirmwareFlasher.Tool/Options.cs
+++ b/nanoFirmwareFlasher.Tool/Options.cs
@@ -216,7 +216,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             "platform",
             Required = false,
             Default = null,
-            HelpText = "Target platform. Acceptable values are: esp32, stm32, cc13x2, gg11.")]
+            HelpText = "Target platform. Acceptable values are: esp32, stm32, cc13x2, efm32.")]
         public SupportedPlatform? Platform { get; set; }
 
         /// <summary>

--- a/nanoFirmwareFlasher.Tool/Program.cs
+++ b/nanoFirmwareFlasher.Tool/Program.cs
@@ -487,8 +487,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     }
                     else if (o.TargetName.StartsWith("SL"))
                     {
-                        // candidates for Silabs GG11
-                        o.Platform = SupportedPlatform.gg11;
+                        // candidates for Silabs EFM32 Gecko
+                        o.Platform = SupportedPlatform.efm32;
                     }
                     else
                     {
@@ -522,10 +522,10 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     o.Platform = SupportedPlatform.stm32;
                 }
-                // GG11 related
+                // EFM32 related
                 else if (o.ListJLinkDevices)
                 {
-                    o.Platform = SupportedPlatform.gg11;
+                    o.Platform = SupportedPlatform.efm32;
                 }
                 // drivers install
                 else if (o.TIInstallXdsDrivers)
@@ -708,7 +708,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
 
             #region Silabs Giant Gecko S1 platform options
 
-            if (o.Platform == SupportedPlatform.gg11)
+            if (o.Platform == SupportedPlatform.efm32)
             {
                 var manager = new SilabsManager(o, _verbosityLevel);
 

--- a/nanoFirmwareFlasher.Tool/SilabsManager.cs
+++ b/nanoFirmwareFlasher.Tool/SilabsManager.cs
@@ -22,7 +22,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 throw new ArgumentNullException(nameof(options));
             }
 
-            if (options.Platform != SupportedPlatform.gg11)
+            if (options.Platform != SupportedPlatform.efm32)
             {
                 throw new NotSupportedException($"{nameof(options)} - {options.Platform}");
             }
@@ -38,7 +38,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             {
                 OutputWriter.ForegroundColor = ConsoleColor.Red;
                 OutputWriter.WriteLine();
-                OutputWriter.WriteLine($"Cannot determine the best matching target for a {SupportedPlatform.gg11} device.");
+                OutputWriter.WriteLine($"Cannot determine the best matching target for a {SupportedPlatform.efm32} device.");
                 OutputWriter.WriteLine();
                 OutputWriter.ForegroundColor = ConsoleColor.White;
                 return ExitCodes.OK;


### PR DESCRIPTION
## Description
- Replace GG11 with EFM32 for Silabs EFM32 series.
- Added nxp to supported platforms.
- Update enums, comments and readme accordingly.

## Motivation and Context
- There was an inconsistency on the platform naming. Giant Gecko was the only one using the series name on the platform. Which was wrong.
- NXP was missing from the platform list, despite not being supported (yet) by nanoff.
- These changes were prompted by #309.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
