### PR TITLE
Fix Cloudsmith query

### DIFF
--- a/nanoFirmwareFlasher.Tests/FirmwarePackageTests.cs
+++ b/nanoFirmwareFlasher.Tests/FirmwarePackageTests.cs
@@ -23,17 +23,28 @@ namespace nanoFirmwareFlasher.Tests
             using var output = new OutputWriterHelper();
 
             #region Get the stable packages
-            List<CloudSmithPackageDetail> stable = FirmwarePackage.GetTargetList(false, false, null, VerbosityLevel.Diagnostic);
+
+            List<CloudSmithPackageDetail> stable = FirmwarePackage.GetTargetList(
+                false,
+                false,
+                null,
+                VerbosityLevel.Diagnostic);
+
             Assert.IsNotNull(stable);
             Assert.AreNotEqual(0, stable.Count);
-            output.AssertAreEqual("Listing  targets from 'nanoframework-images' repository [STABLE]...");
+
             #endregion
 
             #region Get the preview packages
+
             output.Reset();
-            List<CloudSmithPackageDetail> preview = FirmwarePackage.GetTargetList(false, true, null, VerbosityLevel.Quiet);
+            List<CloudSmithPackageDetail> preview = FirmwarePackage.GetTargetList(
+                false,
+                true,
+                null,
+                VerbosityLevel.Quiet);
+
             Assert.IsNotNull(preview);
-            output.AssertAreEqual("");
 
             // Assert that the preview packages are not part of the stable package list
             foreach (CloudSmithPackageDetail previewPackage in preview)
@@ -42,14 +53,20 @@ namespace nanoFirmwareFlasher.Tests
                                 where s.Name == previewPackage.Name && s.Version == previewPackage.Version
                                 select s).Any());
             }
+
             #endregion
 
             #region Get the stable esp32 packages
+
             output.Reset();
-            List<CloudSmithPackageDetail> stableEsp32 = FirmwarePackage.GetTargetList(false, false, SupportedPlatform.esp32, VerbosityLevel.Diagnostic);
+            List<CloudSmithPackageDetail> stableEsp32 = FirmwarePackage.GetTargetList(
+                false,
+                false,
+                SupportedPlatform.esp32,
+                VerbosityLevel.Diagnostic);
+
             Assert.IsNotNull(stableEsp32);
             Assert.AreNotEqual(0, stableEsp32.Count);
-            output.AssertAreEqual("Listing esp32 targets from 'nanoframework-images' repository [STABLE]...");
 
             // Assert that there are more stable packages than for the esp32
             Assert.IsTrue(stableEsp32.Count < stable.Count);
@@ -57,10 +74,10 @@ namespace nanoFirmwareFlasher.Tests
             // Assert that all esp32 packages are in the stable list
             foreach (CloudSmithPackageDetail esp32Package in stableEsp32)
             {
-                Assert.IsTrue((from s in stable
-                               where s.Name == esp32Package.Name && s.Version == esp32Package.Version
-                               select s).Any());
+                Assert.IsTrue(stable.Any(s => s.Name == esp32Package.Name && s.Version == esp32Package.Version),
+                              $"Package {esp32Package.Name} with version {esp32Package.Version} is not in the stable list.");
             }
+
             #endregion
         }
 
@@ -74,7 +91,7 @@ namespace nanoFirmwareFlasher.Tests
             List<CloudSmithPackageDetail> stable = FirmwarePackage.GetTargetList(true, false, null, VerbosityLevel.Diagnostic);
             Assert.IsNotNull(stable);
             Assert.AreNotEqual(0, stable.Count);
-            output.AssertAreEqual("Listing  targets from 'nanoframework-images-community-targets' repository...");
+            
             #endregion
 
             #region Get the stable esp32 packages


### PR DESCRIPTION
## Description
- Now using page size of 100 instead of a speculative value of 500.
- Code is now performing a paged query to get all packages until it has them all.
- Rework ListReferenceTargets test to remove assert on output and add a meaningful output message on failure.

## Motivation and Context
- Fixe unit test [failing](https://dev.azure.com/nanoframework/nanoFirmwareFlasher/_build/results?buildId=53429&view=results) because there were over 500 packages listed.
- Better use a paged query approach instead of trying to best guess a good page number to encompass all available packages.
- Asserting the output of the `GetTargetList` feels a bit too much as the core result from the call (listing the packages) has already plenty of tests to validate the content.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Unit test included.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
