### PR TITLE
Update default firmware names

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Operations.cs
@@ -245,24 +245,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     if (esp32Device.ChipName.Contains("revision v0.2"))
                     {
                         // this is the "default" one we're offering
-                        revisionSuffix = "";
-                    }
-                    else if (esp32Device.ChipName.Contains("revision v0.3") || esp32Device.ChipName.Contains("revision v0.4"))
-                    {
-                        // all the others (rev3 and rev4) will take rev3
-                        revisionSuffix = "_REV3";
+                        revisionSuffix = "_BETA";
                     }
                     else
-                    {
-                        OutputWriter.ForegroundColor = ConsoleColor.Red;
-
-                        OutputWriter.WriteLine("");
-                        OutputWriter.WriteLine($"Unsupported ESP32_C3 revision.");
-                        OutputWriter.WriteLine("");
-
-                        OutputWriter.ForegroundColor = ConsoleColor.White;
-
-                        return ExitCodes.E9000;
+                    { 
+                        // all the others (rev3, rev4, rev1.1 and above) will take default
+                        revisionSuffix = "";
                     }
 
                     // compose target name
@@ -272,7 +260,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     
                     // compose target name
-                    targetName = $"ESP32_C5_THREAD_USB";
+                    targetName = $"ESP32_C5_THREA";
                 }
                 else if (esp32Device.ChipType == "ESP32-C6")
                 {
@@ -281,7 +269,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
                 else if (esp32Device.ChipType == "ESP32-C61")
                 {
-                    targetName = $"ESP32_C61_USB";
+                    targetName = $"ESP32_C61";
                 }
                 else if (esp32Device.ChipType == "ESP32-H2")
                 {
@@ -316,25 +304,19 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     //          V001          |     0 (bug in logs)       | v0.1
                     //          V002          |           n/a             | v0.2
 
-                    string revisionSuffix;
+                    string revisionSuffix = "_OCTAL";
 
                     // so far we are only offering a single ESP32_S3 build
                     if (esp32Device.ChipName.Contains("revision v0.0") || esp32Device.ChipName.Contains("revision v0.1") || esp32Device.ChipName.Contains("revision v0.2"))
                     {
                         revisionSuffix = "";
                     }
-                    else
-                    {
-                        OutputWriter.ForegroundColor = ConsoleColor.Red;
 
-                        OutputWriter.WriteLine("");
-                        OutputWriter.WriteLine($"Unsupported ESP32_S3 revision.");
-                        OutputWriter.WriteLine("");
+                    OutputWriter.WriteLine($"For ESP32-S3 series nanoff isn't able to make an educated guess on the type of psram your board is using.");
+                    OutputWriter.WriteLine($"If your target is no showing any psram than call nanoff again with the specific firmware name. i.e ESP32_S3_QUAD");
+                    OutputWriter.WriteLine($"Please provide a valid target name using this option '--target ESP32_S3_QUAD' instead of '--platform esp32'.");
+                    OutputWriter.WriteLine("");
 
-                        OutputWriter.ForegroundColor = ConsoleColor.White;
-
-                        return ExitCodes.E9000;
-                    }
 
                     // compose target name
                     targetName = $"ESP32_S3{revisionSuffix}";
@@ -369,7 +351,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     }
 
                     // compose target name
-                    targetName = $"ESP32_P4_UART{revisionSuffix}";
+                    targetName = $"ESP32_P4{revisionSuffix}";
                 }
 
                 if (showFwOnly)


### PR DESCRIPTION
## Description
Change the default firmware names if just the --platform option is used.
The default names are changing to reduce number of different firmware names by auto selecting between usb and uart connections. There won't be anymore usb or uart versions.
 

## Motivation and Context
Change of firmware names

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
