### PR TITLE
Detect S3 psram type based on size

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Operations.cs
@@ -287,16 +287,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 }
                 else if (esp32Device.ChipType == "ESP32-S3")
                 {
-                    // version schema for ESP32-S3
-                    //Previously Used Schemes | Previous Identification   | vM.X
-                    //          V000          |           n/a             | v0.0
-                    //          V001          |     0 (bug in logs)       | v0.1
-                    //          V002          |           n/a             | v0.2
-
-                    // early silicon revisions had QUAD PSRAM; newer revisions default to OCTAL
+                    // Most new esp32_s3 use octal PSRAM, but some older use quad PSRAM. These are normally 2Mb in size.
                     string revisionSuffix = "_OCTAL";
 
-                    if (esp32Device.ChipName.Contains("revision v0.0") || esp32Device.ChipName.Contains("revision v0.1") || esp32Device.ChipName.Contains("revision v0.2"))
+                    // Default to QUAD if a 2Mb PSRAM detected
+                    if (esp32Device.PSRamAvailable == PSRamAvailability.Yes && esp32Device.PsRamSize == 2)
                     {
                         revisionSuffix = "_QUAD";
                     }
@@ -305,7 +300,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                     targetName = $"ESP32_S3{revisionSuffix}";
 
                     string psRamAlternative = revisionSuffix == "_OCTAL" ? "ESP32_S3_QUAD" : "ESP32_S3_OCTAL";
-                    OutputWriter.WriteLine($"For ESP32-S3 series nanoff isn't able to make an educated guess on the type of PSRAM your board is using.");
+                    OutputWriter.WriteLine($"For ESP32-S3 series nanoff isn't always able to guess the type of PSRAM your board is using.");
                     OutputWriter.WriteLine($"If PSRAM is not detected after flashing, rerun nanoff with this option '--target {psRamAlternative}' instead of '--platform esp32'.");
                     OutputWriter.WriteLine("");
                 }


### PR DESCRIPTION
## Description
Improved the way QUAD psram type was detect for ESP32_S3 targets

Now will choose QUAD type firmware if psram is 2MB size (older boards)

## Motivation and Context
Previous way not working

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

Tested locally with S3 super min with 2MB psram and QUAD was chosen.
The S3 8MB psram board succesfully loaded OCTAL frimware

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
