### PR TITLE
Refactor exception classes, correct build null warnings, improve unit tests

### DIFF
--- a/nanoFirmwareFlasher.Library/Esp32Serial/Esp32BootloaderClient.cs
+++ b/nanoFirmwareFlasher.Library/Esp32Serial/Esp32BootloaderClient.cs
@@ -179,8 +179,6 @@ namespace nanoFramework.Tools.FirmwareFlasher.Esp32Serial
                 //  1. Consumes boot log bytes so they don't confuse SYNC parsing.
                 //  2. Detects the boot mode (download vs normal) for better diagnostics.
                 // Matches esptool's boot log detection in _connect_attempt().
-                bool bootLogDetected = false;
-                bool downloadMode = false;
                 int waiting = _port.BytesToRead;
 
                 if (waiting > 0)
@@ -201,9 +199,7 @@ namespace nanoFramework.Tools.FirmwareFlasher.Esp32Serial
 
                     if (bootMatch.Success)
                     {
-                        bootLogDetected = true;
-                        downloadMode = bootMatch.Groups[2].Success;
-
+                        bool downloadMode = bootMatch.Groups[2].Success;
                         if (Verbosity >= VerbosityLevel.Diagnostic)
                         {
                             OutputWriter.WriteLine(

--- a/nanoFirmwareFlasher.Library/Exceptions/CantConnectToDfuDeviceException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/CantConnectToDfuDeviceException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Couldn't open the specified DFU device.
     /// </summary>
-    [Serializable]
     public class CantConnectToDfuDeviceException : Exception
     {
         /// <summary>
@@ -35,15 +33,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public CantConnectToDfuDeviceException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// DFU device connection exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected CantConnectToDfuDeviceException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/CantConnectToJLinkDeviceException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/CantConnectToJLinkDeviceException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Couldn't open the specified J-Link device.
     /// </summary>
-    [Serializable]
     public class CantConnectToJLinkDeviceException : Exception
     {
         /// <summary>
@@ -35,15 +33,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public CantConnectToJLinkDeviceException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Cannot connect to the JLINK device exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected CantConnectToJLinkDeviceException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/CantConnectToJtagDeviceException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/CantConnectToJtagDeviceException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Couldn't open the specified JTAG device.
     /// </summary>
-    [Serializable]
     public class CantConnectToJtagDeviceException : Exception
     {
         /// <summary>
@@ -37,14 +35,5 @@ namespace nanoFramework.Tools.FirmwareFlasher
         public CantConnectToJtagDeviceException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-        /// <summary>
-        /// Cannot connect to JTAG device exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected CantConnectToJtagDeviceException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
-    }
+   }
 }

--- a/nanoFirmwareFlasher.Library/Exceptions/CantConnectToNanoDeviceException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/CantConnectToNanoDeviceException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Couldn't open the specified .NET nanoFramework device.
     /// </summary>
-    [Serializable]
     public class CantConnectToNanoDeviceException : Exception
     {
         /// <summary>
@@ -35,15 +33,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public CantConnectToNanoDeviceException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Cannot connect to device exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected CantConnectToNanoDeviceException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/DfuFileDoesNotExistException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/DfuFileDoesNotExistException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// The DFU file specified does not exist.
     /// </summary>
-    [Serializable]
     public class DfuFileDoesNotExistException : Exception
     {
         /// <summary>
@@ -35,15 +33,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public DfuFileDoesNotExistException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// DFU file does not exist exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected DfuFileDoesNotExistException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/DfuOperationFailedException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/DfuOperationFailedException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Verification of DFU write failed.
     /// </summary>
-    [Serializable]
     public class DfuOperationFailedException : Exception
     {
         /// <summary>
@@ -35,15 +33,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public DfuOperationFailedException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// DFU operation failed exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected DfuOperationFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/EraseEsp32FlashException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/EraseEsp32FlashException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Error erasing ESP32 flash.
     /// </summary>
-    [Serializable]
     public class EraseEsp32FlashException : Exception
     {
         /// <summary>
@@ -34,15 +32,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public EraseEsp32FlashException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// ESP32 tool erase exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context</param>
-        protected EraseEsp32FlashException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/EspToolExecutionException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/EspToolExecutionException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Error executing an ESP32 serial protocol command.
     /// </summary>
-    [Serializable]
     public class EspToolExecutionException : Exception
     {
         /// <summary>
@@ -42,15 +40,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public EspToolExecutionException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// ESP32 tool execution exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected EspToolExecutionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/NanoDeviceOperationFailedException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/NanoDeviceOperationFailedException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Verification of DFU write failed.
     /// </summary>
-    [Serializable]
     public class NanoDeviceOperationFailedException : Exception
     {
         /// <summary>
@@ -35,15 +33,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public NanoDeviceOperationFailedException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// NanoFramework Device Operation Exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected NanoDeviceOperationFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/NoOperationPerformedException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/NoOperationPerformedException.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
@@ -34,15 +33,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public NoOperationPerformedException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// No operation performed exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected NoOperationPerformedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/ReadEsp32FlashException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/ReadEsp32FlashException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Error reading from ESP32 flash.
     /// </summary>
-    [Serializable]
     public class ReadEsp32FlashException : Exception
     {
         /// <summary>
@@ -34,15 +32,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public ReadEsp32FlashException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// ESP32 tool flash exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected ReadEsp32FlashException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/SilinkExecutionException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/SilinkExecutionException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Error executing SI Link command.
     /// </summary>
-    [Serializable]
     public class SilinkExecutionException : Exception
     {
         /// <summary>
@@ -41,15 +39,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public SilinkExecutionException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// SI Link Exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected SilinkExecutionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/StLinkCliExecutionException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/StLinkCliExecutionException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Error executing STM32 Programmer CLI command.
     /// </summary>
-    [Serializable]
     public class StLinkCliExecutionException : Exception
     {
         /// <summary>
@@ -41,15 +39,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public StLinkCliExecutionException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// STM32 Programmer CLI Exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected StLinkCliExecutionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/Stm32UartBootloaderException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/Stm32UartBootloaderException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Error communicating with STM32 UART bootloader.
     /// </summary>
-    [Serializable]
     public class Stm32UartBootloaderException : Exception
     {
         /// <summary>
@@ -35,15 +33,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public Stm32UartBootloaderException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// STM32 UART bootloader communication exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected Stm32UartBootloaderException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/UniflashCliExecutionException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/UniflashCliExecutionException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Error executing TI Uniflash CLI command.
     /// </summary>
-    [Serializable]
     public class UniflashCliExecutionException : Exception
     {
         /// <summary>
@@ -41,15 +39,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public UniflashCliExecutionException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// UniFlash CLI Execution Exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected UniflashCliExecutionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Exceptions/WriteEsp32FlashException.cs
+++ b/nanoFirmwareFlasher.Library/Exceptions/WriteEsp32FlashException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher
 {
     /// <summary>
     /// Error writing to ESP32 flash.
     /// </summary>
-    [Serializable]
     public class WriteEsp32FlashException : Exception
     {
         /// <summary>
@@ -34,15 +32,6 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public WriteEsp32FlashException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// Write the ESPP32 flash exception. 
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected WriteEsp32FlashException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Library/Stm32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Stm32Operations.cs
@@ -32,7 +32,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="fitCheck">Checks whether the firmware will fit.</param>
         /// <param name="updateInterface">The connection interface.</param>
         /// <param name="verbosity">The verbosity level to use.</param>
-        /// <param name="verify">Whether to verify the flash after programming.</param>
+        /// <param name="verify">Whether to verify the flash after programming when supported by the selected transport.</param>
         /// <returns>The outcome.</returns>
         public static async System.Threading.Tasks.Task<ExitCodes> UpdateFirmwareAsync(
             string targetName,

--- a/nanoFirmwareFlasher.Library/Stm32Operations.cs
+++ b/nanoFirmwareFlasher.Library/Stm32Operations.cs
@@ -32,6 +32,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="fitCheck">Checks whether the firmware will fit.</param>
         /// <param name="updateInterface">The connection interface.</param>
         /// <param name="verbosity">The verbosity level to use.</param>
+        /// <param name="verify">Whether to verify the flash after programming.</param>
         /// <returns>The outcome.</returns>
         public static async System.Threading.Tasks.Task<ExitCodes> UpdateFirmwareAsync(
             string targetName,

--- a/nanoFirmwareFlasher.Library/Swd/SwdProtocolException.cs
+++ b/nanoFirmwareFlasher.Library/Swd/SwdProtocolException.cs
@@ -4,14 +4,12 @@
 //
 
 using System;
-using System.Runtime.Serialization;
 
 namespace nanoFramework.Tools.FirmwareFlasher.Swd
 {
     /// <summary>
     /// Error communicating via CMSIS-DAP SWD protocol.
     /// </summary>
-    [Serializable]
     public class SwdProtocolException : Exception
     {
         /// <summary>
@@ -35,15 +33,6 @@ namespace nanoFramework.Tools.FirmwareFlasher.Swd
         /// <param name="message">Message to display.</param>
         /// <param name="innerException">The exception to display.</param>
         public SwdProtocolException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        /// <summary>
-        /// SWD protocol communication exception.
-        /// </summary>
-        /// <param name="info">Serialized information.</param>
-        /// <param name="context">Streamed context.</param>
-        protected SwdProtocolException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/nanoFirmwareFlasher.Tests/CC13x26x2DeviceTests.cs
+++ b/nanoFirmwareFlasher.Tests/CC13x26x2DeviceTests.cs
@@ -139,10 +139,10 @@ namespace nanoFirmwareFlasher.Tests
 
             try
             {
-                var device = new CC13x26x2Device("config.ccxml");
-                var result = device.FlashBinFiles(
-                    new List<string> { tempFile },
-                    new List<string> { null });
+                CC13x26x2Device device = new("config.ccxml");
+                List<string> filePaths = [tempFile];
+                List<string> addresses = [null!];
+                ExitCodes result = device.FlashBinFiles(filePaths, addresses);
 
                 Assert.AreEqual(ExitCodes.E5007, result);
             }

--- a/nanoFirmwareFlasher.Tests/Esp32SerialProtocolTests.cs
+++ b/nanoFirmwareFlasher.Tests/Esp32SerialProtocolTests.cs
@@ -810,7 +810,7 @@ namespace nanoFirmwareFlasher.Tests
             };
 
             // Parse all and find the ReadReg response
-            Esp32ResponsePacket readRegResponse = null;
+            Esp32ResponsePacket? readRegResponse = null;
 
             foreach (var payload in responses)
             {
@@ -1662,9 +1662,10 @@ namespace nanoFirmwareFlasher.Tests
         public void ProjectFile_NoEsptoolBinaryReferences()
         {
             // Verify the .csproj no longer references esptool binaries
-            string projectDir = Path.GetDirectoryName(typeof(EspTool).Assembly.Location);
+            string? projectDir = Path.GetDirectoryName(typeof(EspTool).Assembly.Location);
+
             // Walk up to find the source project file
-            string repoRoot = projectDir;
+            string? repoRoot = projectDir;
             while (repoRoot != null && !File.Exists(Path.Combine(repoRoot, "nanoFirmwareFlasher.sln")))
             {
                 repoRoot = Path.GetDirectoryName(repoRoot);

--- a/nanoFirmwareFlasher.Tests/FileDeploymentTests.cs
+++ b/nanoFirmwareFlasher.Tests/FileDeploymentTests.cs
@@ -91,6 +91,8 @@ namespace nanoFirmwareFlasher.Tests
 
             var config = JsonSerializer.Deserialize<FileDeploymentConfiguration>(json, s_jsonOptions);
 
+            Assert.IsNotNull(config);
+            Assert.IsNotNull(config.Files);
             Assert.AreEqual(3, config.Files.Count);
         }
 
@@ -106,6 +108,7 @@ namespace nanoFirmwareFlasher.Tests
 
             var config = JsonSerializer.Deserialize<FileDeploymentConfiguration>(json, s_jsonOptions);
 
+            Assert.IsNotNull(config);
             Assert.IsNotNull(config.Files);
             Assert.AreEqual(1, config.Files.Count);
             Assert.IsNull(config.Files[0].SourceFilePath);
@@ -124,6 +127,7 @@ namespace nanoFirmwareFlasher.Tests
 
             var config = JsonSerializer.Deserialize<FileDeploymentConfiguration>(json, s_jsonOptions);
 
+            Assert.IsNotNull(config);
             Assert.AreEqual(string.Empty, config.Files[0].SourceFilePath);
         }
 
@@ -138,6 +142,7 @@ namespace nanoFirmwareFlasher.Tests
 
             var config = JsonSerializer.Deserialize<FileDeploymentConfiguration>(json, s_jsonOptions);
 
+            Assert.IsNotNull(config);
             Assert.IsNull(config.SerialPort);
         }
 
@@ -148,6 +153,7 @@ namespace nanoFirmwareFlasher.Tests
 
             var config = JsonSerializer.Deserialize<FileDeploymentConfiguration>(json, s_jsonOptions);
 
+            Assert.IsNotNull(config);
             Assert.IsNotNull(config.Files);
             Assert.AreEqual(0, config.Files.Count);
         }
@@ -159,6 +165,7 @@ namespace nanoFirmwareFlasher.Tests
 
             var config = JsonSerializer.Deserialize<FileDeploymentConfiguration>(json, s_jsonOptions);
 
+            Assert.IsNotNull(config);
             Assert.AreEqual("COM8", config.SerialPort);
         }
 

--- a/nanoFirmwareFlasher.Tests/IntelHexParserTests.cs
+++ b/nanoFirmwareFlasher.Tests/IntelHexParserTests.cs
@@ -13,7 +13,7 @@ namespace nanoFirmwareFlasher.Tests
     [TestClass]
     public class IntelHexParserTests
     {
-        private string _testDir;
+        private string? _testDir;
 
         [TestInitialize]
         public void Setup()
@@ -153,6 +153,7 @@ namespace nanoFirmwareFlasher.Tests
         [ExpectedException(typeof(FileNotFoundException))]
         public void Parse_NonExistentFile_ThrowsFileNotFound()
         {
+            Assert.IsNotNull(_testDir, "Test directory should be initialized");
             IntelHexParser.Parse(Path.Combine(_testDir, "nonexistent.hex"));
         }
 
@@ -443,7 +444,7 @@ namespace nanoFirmwareFlasher.Tests
 
         private string WriteHexFile(string content)
         {
-            string path = Path.Combine(_testDir, Guid.NewGuid().ToString("N") + ".hex");
+            string path = Path.Combine(_testDir!, Guid.NewGuid().ToString("N") + ".hex");
             File.WriteAllText(path, content);
             return path;
         }

--- a/nanoFirmwareFlasher.Tests/ManagerAndEnumTests.cs
+++ b/nanoFirmwareFlasher.Tests/ManagerAndEnumTests.cs
@@ -162,6 +162,7 @@ namespace nanoFirmwareFlasher.Tests
         public void ExitCodes_OK_HasDisplayAttribute()
         {
             var field = typeof(ExitCodes).GetField(nameof(ExitCodes.OK));
+            Assert.IsNotNull(field, "ExitCodes.OK field should exist");
             var display = field.GetCustomAttribute<DisplayAttribute>();
             Assert.IsNotNull(display, "ExitCodes.OK should have a Display attribute");
         }
@@ -190,12 +191,12 @@ namespace nanoFirmwareFlasher.Tests
         public void ExitCodes_E1000_SuggestsNativeAlternatives()
         {
             var field = typeof(ExitCodes).GetField(nameof(ExitCodes.E1000));
+            Assert.IsNotNull(field);
             var display = field.GetCustomAttribute<DisplayAttribute>();
-            Assert.IsNotNull(display);
 
-            string name = display.Name;
+            string? name = display!.Name;
             Assert.IsTrue(
-                name.Contains("nativedfu") || name.Contains("uart"),
+                name!.Contains("nativedfu") || name!.Contains("uart"),
                 "E1000 should suggest native alternatives");
         }
 
@@ -203,12 +204,12 @@ namespace nanoFirmwareFlasher.Tests
         public void ExitCodes_E5001_SuggestsNativeAlternatives()
         {
             var field = typeof(ExitCodes).GetField(nameof(ExitCodes.E5001));
+            Assert.IsNotNull(field, "ExitCodes.E5001 field should exist");
             var display = field.GetCustomAttribute<DisplayAttribute>();
-            Assert.IsNotNull(display);
 
-            string name = display.Name;
+            string? name = display!.Name;
             Assert.IsTrue(
-                name.Contains("nativestlink") || name.Contains("nativeswd"),
+                name!.Contains("nativestlink") || name!.Contains("nativeswd"),
                 "E5001 should suggest native alternatives");
         }
 

--- a/nanoFirmwareFlasher.Tests/ManagerAndEnumTests.cs
+++ b/nanoFirmwareFlasher.Tests/ManagerAndEnumTests.cs
@@ -193,8 +193,9 @@ namespace nanoFirmwareFlasher.Tests
             var field = typeof(ExitCodes).GetField(nameof(ExitCodes.E1000));
             Assert.IsNotNull(field);
             var display = field.GetCustomAttribute<DisplayAttribute>();
+            Assert.IsNotNull(display, "ExitCodes.E1000 should have a Display attribute");
 
-            string? name = display!.Name;
+            string? name = display.Name;
             Assert.IsTrue(
                 name!.Contains("nativedfu") || name!.Contains("uart"),
                 "E1000 should suggest native alternatives");
@@ -206,8 +207,9 @@ namespace nanoFirmwareFlasher.Tests
             var field = typeof(ExitCodes).GetField(nameof(ExitCodes.E5001));
             Assert.IsNotNull(field, "ExitCodes.E5001 field should exist");
             var display = field.GetCustomAttribute<DisplayAttribute>();
+            Assert.IsNotNull(display, "ExitCodes.E5001 should have a Display attribute");
 
-            string? name = display!.Name;
+            string? name = display.Name;
             Assert.IsTrue(
                 name!.Contains("nativestlink") || name!.Contains("nativeswd"),
                 "E5001 should suggest native alternatives");

--- a/nanoFirmwareFlasher.Tests/Phase10ValidationTests.cs
+++ b/nanoFirmwareFlasher.Tests/Phase10ValidationTests.cs
@@ -130,6 +130,7 @@ namespace nanoFirmwareFlasher.Tests
         public void ExitCode_E5022_HasDisplayAttribute()
         {
             var field = typeof(ExitCodes).GetField(nameof(ExitCodes.E5022));
+            Assert.IsNotNull(field, "ExitCodes.E5022 field should exist");
             var attr = field.GetCustomAttribute<DisplayAttribute>();
             Assert.IsNotNull(attr);
             Assert.IsFalse(string.IsNullOrEmpty(attr.Name));

--- a/nanoFirmwareFlasher.Tests/Phase11DispatchTests.cs
+++ b/nanoFirmwareFlasher.Tests/Phase11DispatchTests.cs
@@ -124,8 +124,9 @@ namespace nanoFirmwareFlasher.Tests
                 null,
                 new[] { typeof(IStmFlashableDevice) },
                 null);
+            Assert.IsNotNull(method, "FlashDeviceFiles helper should exist on Stm32Manager");
 
-            var result = (ExitCodes)method!.Invoke(manager, new object[] { mockDevice })!;
+            var result = (ExitCodes)method.Invoke(manager, new object[] { mockDevice })!;
 
             Assert.AreEqual(ExitCodes.OK, result);
             Assert.AreEqual(VerbosityLevel.Diagnostic, mockDevice.Verbosity);
@@ -177,8 +178,9 @@ namespace nanoFirmwareFlasher.Tests
                 null,
                 new[] { typeof(IStmFlashableDevice) },
                 null);
+            Assert.IsNotNull(method, "FlashDeviceFiles helper should exist on Stm32Manager");
 
-            var result = (ExitCodes)method!.Invoke(manager, new object[] { mockDevice })!;
+            var result = (ExitCodes)method.Invoke(manager, new object[] { mockDevice })!;
 
             Assert.AreEqual(ExitCodes.OK, result);
             Assert.IsFalse(mockDevice.FlashHexCalled);

--- a/nanoFirmwareFlasher.Tests/Phase11DispatchTests.cs
+++ b/nanoFirmwareFlasher.Tests/Phase11DispatchTests.cs
@@ -125,7 +125,7 @@ namespace nanoFirmwareFlasher.Tests
                 new[] { typeof(IStmFlashableDevice) },
                 null);
 
-            var result = (ExitCodes)method.Invoke(manager, new object[] { mockDevice });
+            var result = (ExitCodes)method!.Invoke(manager, new object[] { mockDevice })!;
 
             Assert.AreEqual(ExitCodes.OK, result);
             Assert.AreEqual(VerbosityLevel.Diagnostic, mockDevice.Verbosity);
@@ -151,6 +151,7 @@ namespace nanoFirmwareFlasher.Tests
                 null,
                 new[] { typeof(IStmFlashableDevice) },
                 null);
+            Assert.IsNotNull(method, "FlashDeviceFiles helper should exist on Stm32Manager");
 
             method.Invoke(manager, new object[] { mockDevice });
 
@@ -177,7 +178,7 @@ namespace nanoFirmwareFlasher.Tests
                 new[] { typeof(IStmFlashableDevice) },
                 null);
 
-            var result = (ExitCodes)method.Invoke(manager, new object[] { mockDevice });
+            var result = (ExitCodes)method!.Invoke(manager, new object[] { mockDevice })!;
 
             Assert.AreEqual(ExitCodes.OK, result);
             Assert.IsFalse(mockDevice.FlashHexCalled);

--- a/nanoFirmwareFlasher.Tests/Phase12RobustnessTests.cs
+++ b/nanoFirmwareFlasher.Tests/Phase12RobustnessTests.cs
@@ -271,6 +271,7 @@ namespace nanoFirmwareFlasher.Tests
             {
                 // Set LocationPath via reflection since it's normally set by DownloadAndExtractAsync
                 var prop = typeof(FirmwarePackage).GetProperty("LocationPath");
+                Assert.IsNotNull(prop, "LocationPath property should exist");
                 prop.SetValue(fw, fwDir);
 
                 fw.PostProcessDownloadAndExtract();
@@ -294,6 +295,7 @@ namespace nanoFirmwareFlasher.Tests
             using (var fw = new Stm32Firmware("TEST_TARGET", "1.0.0", false))
             {
                 var prop = typeof(FirmwarePackage).GetProperty("LocationPath");
+                Assert.IsNotNull(prop, "LocationPath property should exist");
                 prop.SetValue(fw, fwDir);
 
                 fw.PostProcessDownloadAndExtract();
@@ -505,7 +507,7 @@ namespace nanoFirmwareFlasher.Tests
                 BindingFlags.NonPublic | BindingFlags.Static);
             Assert.IsNotNull(method);
 
-            uint address = (uint)method.Invoke(null, new object[] { hexFile });
+            uint address = (uint)method!.Invoke(null, new object[] { hexFile })!;
             Assert.AreEqual(0x08000000u, address);
         }
 
@@ -525,8 +527,9 @@ namespace nanoFirmwareFlasher.Tests
             var method = typeof(FirmwarePackage).GetMethod(
                 "FindStartAddressInHexFile",
                 BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
 
-            uint address = (uint)method.Invoke(null, new object[] { hexFile });
+            uint address = (uint)method!.Invoke(null, new object[] { hexFile })!;
             Assert.AreEqual(0x2462u, address);
         }
 
@@ -545,6 +548,7 @@ namespace nanoFirmwareFlasher.Tests
             var method = typeof(FirmwarePackage).GetMethod(
                 "FindStartAddressInHexFile",
                 BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method);
 
             try
             {
@@ -565,6 +569,7 @@ namespace nanoFirmwareFlasher.Tests
         {
             var options = new Options();
             var platformProp = typeof(Options).GetProperty("Platform");
+            Assert.IsNotNull(platformProp, "Platform property should exist");
             platformProp.SetValue(options, (SupportedPlatform?)platform);
             return options;
         }

--- a/nanoFirmwareFlasher.Tests/Phase13NetworkDeploymentTests.cs
+++ b/nanoFirmwareFlasher.Tests/Phase13NetworkDeploymentTests.cs
@@ -432,17 +432,25 @@ namespace nanoFirmwareFlasher.Tests
         public void JLinkCli_CommandTemplates_ContainExpectedTokens()
         {
             // Use reflection to read private const fields
-            var singleTemplate = typeof(JLinkCli).GetField("FlashSingleFileCommandTemplate",
+            FieldInfo? singleTemplate = typeof(JLinkCli).GetField(
+                "FlashSingleFileCommandTemplate",
                 BindingFlags.NonPublic | BindingFlags.Static);
             Assert.IsNotNull(singleTemplate, "FlashSingleFileCommandTemplate should exist");
-            string value = (string)singleTemplate.GetValue(null);
+
+            object? singleValueObject = singleTemplate.GetValue(null);
+            Assert.IsNotNull(singleValueObject);
+            string value = (string)singleValueObject;
             Assert.IsTrue(value.Contains("{FILE_PATH}"));
             Assert.IsTrue(value.Contains("{FLASH_ADDRESS}"));
 
-            var multiTemplate = typeof(JLinkCli).GetField("FlashMultipleFilesCommandTemplate",
+            FieldInfo? multiTemplate = typeof(JLinkCli).GetField(
+                "FlashMultipleFilesCommandTemplate",
                 BindingFlags.NonPublic | BindingFlags.Static);
             Assert.IsNotNull(multiTemplate, "FlashMultipleFilesCommandTemplate should exist");
-            string multiValue = (string)multiTemplate.GetValue(null);
+
+            object? multiValueObject = multiTemplate.GetValue(null);
+            Assert.IsNotNull(multiValueObject);
+            string multiValue = (string)multiValueObject;
             Assert.IsTrue(multiValue.Contains("{LOAD_FILE_LIST}"));
         }
 
@@ -472,7 +480,9 @@ namespace nanoFirmwareFlasher.Tests
             var files = new System.Collections.Generic.List<string> { @"C:\nonexistent\firmware.bin" };
             var shadowFiles = new System.Collections.Generic.List<string>();
 
-            var result = (ExitCodes)method.Invoke(null, new object[] { files, shadowFiles });
+            var invokeResult = method.Invoke(null, new object[] { files, shadowFiles });
+            Assert.IsNotNull(invokeResult, "ProcessFilePaths should return a value");
+            var result = (ExitCodes)invokeResult;
             Assert.AreEqual(ExitCodes.E5004, result);
         }
 
@@ -485,11 +495,14 @@ namespace nanoFirmwareFlasher.Tests
 
             var method = typeof(JLinkCli).GetMethod("ProcessFilePaths",
                 BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.IsNotNull(method, "ProcessFilePaths should exist");
 
             var files = new System.Collections.Generic.List<string> { testFile };
             var shadowFiles = new System.Collections.Generic.List<string>();
 
-            var result = (ExitCodes)method.Invoke(null, new object[] { files, shadowFiles });
+            var invokeResult = method.Invoke(null, new object[] { files, shadowFiles });
+            Assert.IsNotNull(invokeResult, "ProcessFilePaths should return a value");
+            var result = (ExitCodes)invokeResult;
             Assert.AreEqual(ExitCodes.OK, result);
             Assert.AreEqual(1, shadowFiles.Count);
         }

--- a/nanoFirmwareFlasher.Tests/PicoFirmwareTests.cs
+++ b/nanoFirmwareFlasher.Tests/PicoFirmwareTests.cs
@@ -59,9 +59,11 @@ namespace nanoFirmwareFlasher.Tests
             // since we can't call DownloadAndExtractAsync without a real Cloudsmith package
             var firmware = new PicoFirmware("RP_PICO_RP2040", "1.0.0.0", false);
 
-            typeof(PicoFirmware)
-                .GetProperty("BinFilePath", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
-                .SetValue(firmware, binFilePath);
+            var binFilePathProperty = typeof(PicoFirmware)
+                .GetProperty("BinFilePath", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+            Assert.IsNotNull(binFilePathProperty);
+            binFilePathProperty.SetValue(firmware, binFilePath);
 
             // exercise GetUf2Bytes
             byte[] uf2Data = firmware.GetUf2Bytes(PicoUf2Utility.FAMILY_ID_RP2040);

--- a/nanoFirmwareFlasher.Tests/PicoOperationsTests.cs
+++ b/nanoFirmwareFlasher.Tests/PicoOperationsTests.cs
@@ -87,24 +87,24 @@ namespace nanoFirmwareFlasher.Tests
         [TestMethod]
         public void PicoOperations_InferTargetName_MapsChipTypes()
         {
-            MethodInfo method = typeof(PicoOperations).GetMethod(
+            MethodInfo? method = typeof(PicoOperations).GetMethod(
                 "InferTargetName",
                 BindingFlags.NonPublic | BindingFlags.Static);
 
             Assert.IsNotNull(method, "InferTargetName method not found");
 
             // null device returns null (caller must handle the error)
-            string result = (string)method.Invoke(null, new object[] { null });
+            string? result = (string?)method.Invoke(null, new object?[] { null });
             Assert.IsNull(result);
 
             // RP2040 chip maps to RP_PICO_RP2040
             var rp2040 = new PicoDeviceInfo("RP2040", "", "", "", "");
-            result = (string)method.Invoke(null, new object[] { rp2040 });
+            result = (string?)method.Invoke(null, new object?[] { rp2040 });
             Assert.AreEqual("RP_PICO_RP2040", result);
 
             // RP2350 chip maps to RP_PICO_RP2350
             var rp2350 = new PicoDeviceInfo("RP2350", "", "", "", "");
-            result = (string)method.Invoke(null, new object[] { rp2350 });
+            result = (string?)method.Invoke(null, new object?[] { rp2350 });
             Assert.AreEqual("RP_PICO_RP2350", result);
         }
 

--- a/nanoFirmwareFlasher.Tests/StLinkProtocolTests.cs
+++ b/nanoFirmwareFlasher.Tests/StLinkProtocolTests.cs
@@ -290,6 +290,7 @@ namespace nanoFirmwareFlasher.Tests
                 null,
                 new[] { typeof(ISwdTransport) },
                 null);
+            Assert.IsNotNull(constructor);
 
             var swd = constructor.Invoke(new object[] { stLink });
             Assert.IsNotNull(swd);
@@ -474,6 +475,7 @@ namespace nanoFirmwareFlasher.Tests
             Assert.AreEqual(1, displayAttr.Length, "E1000 should have a Display attribute");
 
             var name = ((System.ComponentModel.DataAnnotations.DisplayAttribute)displayAttr[0]).Name;
+            Assert.IsNotNull(name);
             Assert.IsTrue(
                 name.Contains("nativedfu") || name.Contains("native") || name.Contains("uart"),
                 $"E1000 display should suggest native alternatives. Got: {name}");
@@ -490,6 +492,7 @@ namespace nanoFirmwareFlasher.Tests
             Assert.AreEqual(1, displayAttr.Length);
 
             var name = ((System.ComponentModel.DataAnnotations.DisplayAttribute)displayAttr[0]).Name;
+            Assert.IsNotNull(name);
             Assert.IsTrue(
                 name.Contains("nativestlink") || name.Contains("nativeswd") || name.Contains("native"),
                 $"E5001 display should suggest native alternatives. Got: {name}");
@@ -506,6 +509,7 @@ namespace nanoFirmwareFlasher.Tests
             Assert.AreEqual(1, displayAttr.Length);
 
             var name = ((System.ComponentModel.DataAnnotations.DisplayAttribute)displayAttr[0]).Name;
+            Assert.IsNotNull(name);
             Assert.IsTrue(
                 name.Contains("native") || name.Contains("uart"),
                 $"E9010 display should suggest native alternatives. Got: {name}");

--- a/nanoFirmwareFlasher.Tests/Stm32FlashProgrammerTests.cs
+++ b/nanoFirmwareFlasher.Tests/Stm32FlashProgrammerTests.cs
@@ -22,23 +22,27 @@ namespace nanoFirmwareFlasher.Tests
         private static readonly MethodInfo ClassifyDeviceMethod =
             typeof(Stm32FlashProgrammer).GetMethod(
                 "ClassifyDevice",
-                BindingFlags.Static | BindingFlags.NonPublic)!;
+                BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("ClassifyDevice method not found.");
 
         // Use reflection to call internal static GetFlashRegisters(Stm32Family family)
         private static readonly MethodInfo GetFlashRegistersMethod =
             typeof(Stm32FlashProgrammer).GetMethod(
                 "GetFlashRegisters",
-                BindingFlags.Static | BindingFlags.NonPublic)!;
+                BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("GetFlashRegisters method not found.");
 
         // Use reflection to call internal static GetSectorForAddress(uint offset)
         private static readonly MethodInfo GetSectorForAddressMethod =
             typeof(Stm32FlashProgrammer).GetMethod(
                 "GetSectorForAddress",
-                BindingFlags.Static | BindingFlags.NonPublic)!;
+                BindingFlags.Static | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("GetSectorForAddress method not found.");
 
         // Helper to get the Stm32Family enum type
         private static readonly Type FamilyEnumType =
-            typeof(Stm32FlashProgrammer).GetNestedType("Stm32Family", BindingFlags.NonPublic)!;
+            typeof(Stm32FlashProgrammer).GetNestedType("Stm32Family", BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Stm32Family enum not found.");
 
         private static object ClassifyDevice(ushort devId)
         {

--- a/nanoFirmwareFlasher.Tests/Stm32FlashProgrammerTests.cs
+++ b/nanoFirmwareFlasher.Tests/Stm32FlashProgrammerTests.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using nanoFramework.Tools.FirmwareFlasher.Swd;
@@ -23,37 +22,39 @@ namespace nanoFirmwareFlasher.Tests
         private static readonly MethodInfo ClassifyDeviceMethod =
             typeof(Stm32FlashProgrammer).GetMethod(
                 "ClassifyDevice",
-                BindingFlags.Static | BindingFlags.NonPublic);
+                BindingFlags.Static | BindingFlags.NonPublic)!;
 
         // Use reflection to call internal static GetFlashRegisters(Stm32Family family)
         private static readonly MethodInfo GetFlashRegistersMethod =
             typeof(Stm32FlashProgrammer).GetMethod(
                 "GetFlashRegisters",
-                BindingFlags.Static | BindingFlags.NonPublic);
+                BindingFlags.Static | BindingFlags.NonPublic)!;
 
         // Use reflection to call internal static GetSectorForAddress(uint offset)
         private static readonly MethodInfo GetSectorForAddressMethod =
             typeof(Stm32FlashProgrammer).GetMethod(
                 "GetSectorForAddress",
-                BindingFlags.Static | BindingFlags.NonPublic);
+                BindingFlags.Static | BindingFlags.NonPublic)!;
 
         // Helper to get the Stm32Family enum type
         private static readonly Type FamilyEnumType =
-            typeof(Stm32FlashProgrammer).GetNestedType("Stm32Family", BindingFlags.NonPublic);
+            typeof(Stm32FlashProgrammer).GetNestedType("Stm32Family", BindingFlags.NonPublic)!;
 
         private static object ClassifyDevice(ushort devId)
         {
-            return ClassifyDeviceMethod.Invoke(null, new object[] { devId });
+            return ClassifyDeviceMethod.Invoke(null, new object[] { devId })!;
         }
 
         private static object GetFlashRegisters(object family)
         {
-            return GetFlashRegistersMethod.Invoke(null, new object[] { family });
+            return GetFlashRegistersMethod.Invoke(null, new object[] { family })!;
         }
 
         private static int GetSectorForAddress(uint offset)
         {
-            return (int)GetSectorForAddressMethod.Invoke(null, new object[] { offset });
+            // MethodInfo.Invoke can return null; guard against null to satisfy nullable analysis
+            var result = GetSectorForAddressMethod.Invoke(null, new object[] { offset });
+            return (int)(result ?? throw new InvalidOperationException("GetSectorForAddress returned null"));
         }
 
         private static object GetFamilyValue(string name)
@@ -63,7 +64,15 @@ namespace nanoFirmwareFlasher.Tests
 
         private static object GetRegField(object regs, string fieldName)
         {
-            return regs.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public).GetValue(regs);
+            var field = regs.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+            if (field == null)
+                throw new InvalidOperationException($"Field '{fieldName}' not found on type '{regs.GetType()}'.");
+
+            var value = field.GetValue(regs);
+            if (value == null)
+                throw new InvalidOperationException($"Field '{fieldName}' on type '{regs.GetType()}' returned null.");
+
+            return value;
         }
 
         private static uint GetUintRegField(object regs, string fieldName)
@@ -641,9 +650,9 @@ namespace nanoFirmwareFlasher.Tests
             Assert.IsNotNull(m0, "DbgmcuIdcode_M0 constant should exist");
             Assert.IsNotNull(m33, "DbgmcuIdcode_M33 constant should exist");
 
-            Assert.AreEqual(0xE0042000U, (uint)m3m4.GetValue(null));
-            Assert.AreEqual(0x40015800U, (uint)m0.GetValue(null));
-            Assert.AreEqual(0x44024000U, (uint)m33.GetValue(null));
+            Assert.AreEqual(0xE0042000U, (uint)m3m4.GetValue(null)!);
+            Assert.AreEqual(0x40015800U, (uint)m0.GetValue(null)!);
+            Assert.AreEqual(0x44024000U, (uint)m33.GetValue(null)!);
         }
 
         #endregion
@@ -660,8 +669,8 @@ namespace nanoFirmwareFlasher.Tests
 
             Assert.IsNotNull(key1);
             Assert.IsNotNull(key2);
-            Assert.AreEqual(0x45670123U, (uint)key1.GetValue(null));
-            Assert.AreEqual(0xCDEF89ABU, (uint)key2.GetValue(null));
+            Assert.AreEqual(0x45670123U, (uint)key1.GetValue(null)!);
+            Assert.AreEqual(0xCDEF89ABU, (uint)key2.GetValue(null)!);
         }
 
         #endregion


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
- Remove obsolete serialization from exception classes (SysLib0051 guidance, see [link](https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0051))
- Remove unused variables
- Add missing XML documentation
- Correct build nullable warnings
- Improvements in Unit tests.

## Motivation and Context
- Fixes build warnings

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
