### PR TITLE
Fixing flash size for masserase for RP2350

### DIFF
--- a/nanoFirmwareFlasher.Library/PicoDeviceInfo.cs
+++ b/nanoFirmwareFlasher.Library/PicoDeviceInfo.cs
@@ -43,6 +43,12 @@ namespace nanoFramework.Tools.FirmwareFlasher
         public uint FamilyId { get; }
 
         /// <summary>
+        /// External flash size in bytes.
+        /// Defaults to a chip-appropriate value when it can't be read from INFO_UF2.TXT.
+        /// </summary>
+        public uint FlashSizeBytes { get; }
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="chipType">Chip type string.</param>
@@ -50,12 +56,14 @@ namespace nanoFramework.Tools.FirmwareFlasher
         /// <param name="bootloaderVersion">Bootloader version.</param>
         /// <param name="drivePath">Path to UF2 drive.</param>
         /// <param name="driveLabel">Volume label.</param>
+        /// <param name="flashSizeBytes">Detected external flash size in bytes, or <c>null</c> to use defaults.</param>
         public PicoDeviceInfo(
             string chipType,
             string boardId,
             string bootloaderVersion,
             string drivePath,
-            string driveLabel)
+            string driveLabel,
+            uint? flashSizeBytes = null)
         {
             ChipType = chipType;
             BoardId = boardId;
@@ -70,6 +78,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 "RP2350" => PicoUf2Utility.FAMILY_ID_RP2350_ARM,
                 _ => throw new NotSupportedException($"Unknown Pico chip type '{chipType}'. Supported types: RP2040, RP2350."),
             };
+
+            FlashSizeBytes = flashSizeBytes.GetValueOrDefault(GetDefaultFlashSize(chipType));
         }
 
         /// <inheritdoc/>
@@ -81,9 +91,35 @@ namespace nanoFramework.Tools.FirmwareFlasher
             deviceInfo.AppendLine($"Board: {BoardId}");
             deviceInfo.AppendLine($"Bootloader: {BootloaderVersion}");
             deviceInfo.AppendLine($"Drive: {DrivePath} ({DriveLabel})");
+            deviceInfo.AppendLine($"Flash: {FormatFlashSize(FlashSizeBytes)} ({FlashSizeBytes:N0} bytes)");
             deviceInfo.Append($"UF2 Family ID: 0x{FamilyId:X8}");
 
             return deviceInfo.ToString();
+        }
+
+        private static uint GetDefaultFlashSize(string chipType)
+        {
+            return chipType switch
+            {
+                "RP2040" => PicoFirmware.DefaultFlashSize,
+                "RP2350" => PicoFirmware.DefaultFlashSizeRp2350,
+                _ => PicoFirmware.DefaultFlashSize,
+            };
+        }
+
+        private static string FormatFlashSize(uint sizeBytes)
+        {
+            if (sizeBytes % (1024 * 1024) == 0)
+            {
+                return $"{sizeBytes / (1024 * 1024)}MB";
+            }
+
+            if (sizeBytes % 1024 == 0)
+            {
+                return $"{sizeBytes / 1024}KB";
+            }
+
+            return $"{sizeBytes}B";
         }
     }
 }

--- a/nanoFirmwareFlasher.Library/PicoFirmware.cs
+++ b/nanoFirmwareFlasher.Library/PicoFirmware.cs
@@ -23,6 +23,11 @@ namespace nanoFramework.Tools.FirmwareFlasher
         internal const uint DefaultFlashSize = 2 * 1024 * 1024;
 
         /// <summary>
+        /// Default flash size for RP2350 Pico 2 boards (4 MB).
+        /// </summary>
+        internal const uint DefaultFlashSizeRp2350 = 4 * 1024 * 1024;
+
+        /// <summary>
         /// Default deployment region address for managed application.
         /// This must match the deployment region start defined in the nanoFramework target's flash map.
         /// </summary>

--- a/nanoFirmwareFlasher.Library/PicoOperations.cs
+++ b/nanoFirmwareFlasher.Library/PicoOperations.cs
@@ -28,7 +28,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             PicoDeviceInfo deviceInfo,
             VerbosityLevel verbosity)
         {
-            uint flashSize = PicoFirmware.DefaultFlashSize;
+            uint flashSize = ResolveFlashSize(deviceInfo);
             uint familyId = deviceInfo.FamilyId;
 
             if (verbosity >= VerbosityLevel.Normal)
@@ -336,13 +336,15 @@ namespace nanoFramework.Tools.FirmwareFlasher
             // if mass erase requested, pad the UF2 to cover the entire flash
             if (massErase)
             {
+                uint flashSize = ResolveFlashSize(deviceInfo);
+
                 if (verbosity >= VerbosityLevel.Normal)
                 {
                     OutputWriter.ForegroundColor = ConsoleColor.White;
-                    OutputWriter.WriteLine($"Mass erase: padding UF2 to cover full {PicoFirmware.DefaultFlashSize / 1024}KB flash...");
+                    OutputWriter.WriteLine($"Mass erase: padding UF2 to cover full {flashSize / 1024}KB flash...");
                 }
 
-                uf2Data = PicoUf2Utility.PadUf2ToFullFlash(uf2Data, PicoFirmware.DefaultBaseAddress, PicoFirmware.DefaultFlashSize, familyId);
+                uf2Data = PicoUf2Utility.PadUf2ToFullFlash(uf2Data, PicoFirmware.DefaultBaseAddress, flashSize, familyId);
             }
 
             if (verbosity >= VerbosityLevel.Normal)
@@ -487,7 +489,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
 
             // validate address is within the Pico XIP flash window
-            uint flashEnd = PicoFirmware.DefaultBaseAddress + PicoFirmware.DefaultFlashSize;
+            uint flashSize = ResolveFlashSize(deviceInfo);
+            uint flashEnd = PicoFirmware.DefaultBaseAddress + flashSize;
 
             if (address < PicoFirmware.DefaultBaseAddress || address >= flashEnd)
             {
@@ -686,6 +689,15 @@ namespace nanoFramework.Tools.FirmwareFlasher
             return ExitCodes.OK;
         }
 
+        private static uint ResolveFlashSize(PicoDeviceInfo deviceInfo)
+        {
+            if (deviceInfo != null && deviceInfo.FlashSizeBytes > 0)
+            {
+                return deviceInfo.FlashSizeBytes;
+            }
+
+            return PicoFirmware.DefaultFlashSize;
+        }
         /// <summary>
         /// Build the UF2 file name to copy to the BOOTSEL drive.
         /// </summary>

--- a/nanoFirmwareFlasher.Library/PicoUf2Utility.cs
+++ b/nanoFirmwareFlasher.Library/PicoUf2Utility.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -129,6 +130,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
             string boardId = "";
             string bootloaderVersion = "";
             string driveLabel = "";
+            uint? flashSizeBytes = null;
 
             foreach (string line in lines)
             {
@@ -144,6 +146,8 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 {
                     bootloaderVersion = line.Trim();
                 }
+
+                flashSizeBytes ??= TryParseFlashSizeFromInfoLine(line);
             }
 
             // try to get volume label
@@ -172,7 +176,7 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 return null;
             }
 
-            return new PicoDeviceInfo(chipType, boardId, bootloaderVersion, drivePath, driveLabel);
+            return new PicoDeviceInfo(chipType, boardId, bootloaderVersion, drivePath, driveLabel, flashSizeBytes);
         }
 
         /// <summary>
@@ -1029,6 +1033,108 @@ namespace nanoFramework.Tools.FirmwareFlasher
             }
 
             return null;
+        }
+
+        private static uint? TryParseFlashSizeFromInfoLine(string line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return null;
+            }
+
+            int separator = line.IndexOf(':');
+
+            if (separator <= 0)
+            {
+                return null;
+            }
+
+            string key = line.Substring(0, separator).Trim();
+
+            if (key.IndexOf("flash", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return null;
+            }
+
+            string value = line.Substring(separator + 1).Trim();
+
+            if (TryParseFlashSizeToken(value, out uint flashSizeBytes))
+            {
+                return flashSizeBytes;
+            }
+
+            string[] tokens = value.Split(new[] { ' ', '\t', ',', ';', '(', ')' }, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (string token in tokens)
+            {
+                if (TryParseFlashSizeToken(token, out flashSizeBytes))
+                {
+                    return flashSizeBytes;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool TryParseFlashSizeToken(string token, out uint flashSizeBytes)
+        {
+            flashSizeBytes = 0;
+
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return false;
+            }
+
+            string normalized = token
+                .Trim()
+                .TrimEnd('.')
+                .Replace("_", string.Empty)
+                .ToUpperInvariant();
+
+            if (normalized.StartsWith("0X", StringComparison.Ordinal)
+                && uint.TryParse(normalized.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint hexBytes))
+            {
+                flashSizeBytes = hexBytes;
+                return true;
+            }
+
+            uint multiplier = 1;
+
+            if (normalized.EndsWith("MB", StringComparison.Ordinal))
+            {
+                multiplier = 1024u * 1024u;
+                normalized = normalized.Substring(0, normalized.Length - 2);
+            }
+            else if (normalized.EndsWith("M", StringComparison.Ordinal))
+            {
+                multiplier = 1024u * 1024u;
+                normalized = normalized.Substring(0, normalized.Length - 1);
+            }
+            else if (normalized.EndsWith("KB", StringComparison.Ordinal)
+                || normalized.EndsWith("K", StringComparison.Ordinal))
+            {
+                multiplier = 1024u;
+                normalized = normalized.EndsWith("KB", StringComparison.Ordinal)
+                    ? normalized.Substring(0, normalized.Length - 2)
+                    : normalized.Substring(0, normalized.Length - 1);
+            }
+            else if (normalized.EndsWith("B", StringComparison.Ordinal))
+            {
+                normalized = normalized.Substring(0, normalized.Length - 1);
+            }
+
+            if (!uint.TryParse(normalized, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint size))
+            {
+                return false;
+            }
+
+            if (size == 0)
+            {
+                return false;
+            }
+
+            flashSizeBytes = size * multiplier;
+            return true;
         }
 
         #endregion

--- a/nanoFirmwareFlasher.Library/PicoUf2Utility.cs
+++ b/nanoFirmwareFlasher.Library/PicoUf2Utility.cs
@@ -1133,7 +1133,25 @@ namespace nanoFramework.Tools.FirmwareFlasher
                 return false;
             }
 
+            // guard against overflow: if size * multiplier would exceed uint.MaxValue, reject
+            if (multiplier > 1 && size > uint.MaxValue / multiplier)
+            {
+                flashSizeBytes = 0;
+                return false;
+            }
+
             flashSizeBytes = size * multiplier;
+
+            // reject implausible values — known Pico flash sizes are in the low-MB range
+            const uint MinPlausibleFlashSize = 1024u;               // 1 KB
+            const uint MaxPlausibleFlashSize = 64u * 1024u * 1024u; // 64 MB
+
+            if (flashSizeBytes < MinPlausibleFlashSize || flashSizeBytes > MaxPlausibleFlashSize)
+            {
+                flashSizeBytes = 0;
+                return false;
+            }
+
             return true;
         }
 

--- a/nanoFirmwareFlasher.Tests/PicoUf2UtilityTests.cs
+++ b/nanoFirmwareFlasher.Tests/PicoUf2UtilityTests.cs
@@ -234,6 +234,7 @@ namespace nanoFirmwareFlasher.Tests
             Assert.AreEqual("UF2 Bootloader v3.0", result.BootloaderVersion);
             Assert.AreEqual(drivePath, result.DrivePath);
             Assert.AreEqual(PicoUf2Utility.FAMILY_ID_RP2040, result.FamilyId);
+            Assert.AreEqual(PicoFirmware.DefaultFlashSize, result.FlashSizeBytes);
         }
 
         [TestMethod]
@@ -254,6 +255,27 @@ namespace nanoFirmwareFlasher.Tests
             Assert.AreEqual("RP2350", result.ChipType);
             Assert.AreEqual("RP2350", result.BoardId);
             Assert.AreEqual(PicoUf2Utility.FAMILY_ID_RP2350_ARM, result.FamilyId);
+            Assert.AreEqual(PicoFirmware.DefaultFlashSizeRp2350, result.FlashSizeBytes);
+        }
+
+        [TestMethod]
+        public void DetectDevice_WithFlashSizeLine_UsesParsedSize()
+        {
+            string testDirectory = TestDirectoryHelper.GetTestDirectory(TestContext);
+            string drivePath = Path.Combine(testDirectory, "RP2350-size");
+            Directory.CreateDirectory(drivePath);
+
+            File.WriteAllText(Path.Combine(drivePath, "INFO_UF2.TXT"),
+                "UF2 Bootloader v1.0\r\n" +
+                "Model: Raspberry Pi RP2350\r\n" +
+                "Board-ID: RP2350\r\n" +
+                "Flash size: 8MB\r\n");
+
+            PicoDeviceInfo result = PicoUf2Utility.DetectDevice(drivePath);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("RP2350", result.ChipType);
+            Assert.AreEqual(8u * 1024u * 1024u, result.FlashSizeBytes);
         }
 
         [TestMethod]
@@ -330,6 +352,7 @@ namespace nanoFirmwareFlasher.Tests
             var info = new PicoDeviceInfo("RP2040", "RPI-RP2", "v3.0", "/media/RPI-RP2", "RPI-RP2");
 
             Assert.AreEqual(PicoUf2Utility.FAMILY_ID_RP2040, info.FamilyId);
+            Assert.AreEqual(PicoFirmware.DefaultFlashSize, info.FlashSizeBytes);
         }
 
         [TestMethod]
@@ -338,6 +361,7 @@ namespace nanoFirmwareFlasher.Tests
             var info = new PicoDeviceInfo("RP2350", "RP2350", "v1.0", "/Volumes/RP2350", "RP2350");
 
             Assert.AreEqual(PicoUf2Utility.FAMILY_ID_RP2350_ARM, info.FamilyId);
+            Assert.AreEqual(PicoFirmware.DefaultFlashSizeRp2350, info.FlashSizeBytes);
         }
 
         [TestMethod]


### PR DESCRIPTION
<!--- In the TITLE (↑↑↑↑ above ↑↑↑↑ **NOT HERE**) provide a general, short summary of your changes -->
<!--- Please DO NOT use references to other PR's or issues -->

## Description
<!--- Describe your changes in detail -->
<!--- Bulleted list. Full sentences. Ending with a dot. -->
Fixing flash size for masserase for RP2350

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this **fixes** OR **closes** OR  **resolves** an open issue, please link to the issue there using the template bellow (mind the pattern to link there as all issues are tracked in the Home repository) -->
<!--- **JUST** replace NNNNN with the issue number -->
- Fixing flash size for masserase for RP2350
- was 2K like RP2040

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On real devices

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
